### PR TITLE
Fix hyperparameter logging crash with missing config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Keep it human-readable, your future self will thank you!
  - Moved callbacks into folder to fascilitate future refactor
  - Adjusted PyPI release infrastructure to common ECMWF workflow
  - Bumped versions in Pre-commit hooks
+ - Fix crash when logging hyperparameters with missing values in the config
 
 ### Removed
  - Dependency on mlflow-export-import

--- a/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -27,6 +27,7 @@ from pytorch_lightning.loggers.mlflow import _flatten_dict
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 from anemoi.training.diagnostics.mlflow.auth import TokenAuth
+from anemoi.training.utils.jsonify import map_config_to_primitives
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -454,6 +455,11 @@ class AnemoiMLflowLogger(MLFlowLogger):
         """Overwrite the log_hyperparams method to flatten config params using '.'."""
         if self._flag_log_hparams:
             params = _convert_params(params)
+
+            # this is needed to resolve optional missing config values to a string, instead of raising a missing error
+            if config := params.get("config"):
+                params["config"] = map_config_to_primitives(config)
+
             params = _flatten_dict(params, delimiter=".")  # Flatten dict with '.' to not break API queries
             params = self._clean_params(params)
 


### PR DESCRIPTION
The logger does its own serialisation of the config in `log_hyperparams`, which will trigger missing value errors if any optional config entries are still missing (such as wandb.entity).

This PR makes sure the config entry in the hyper parameters is serialisable without throwing missing value errors. Missing config entries will be resolved to a ??? string.