### PR TITLE
fix: minor errors in two callback plot functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Keep it human-readable, your future self will thank you!
  - `__future__` annotations for typehints
  - Added Typehints where missing
  - Added Changelog
+ - Correct errors in callback plots
 
 ### Changed
 

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -488,7 +488,7 @@ class PlotLoss(BasePlotCallback):
         batch_idx: int,
     ) -> None:
         if batch_idx % self.plot_frequency == 0:
-            self.plot(trainer, pl_module, outputs, batch, epoch=trainer.current_epoch)
+            self.plot(trainer, pl_module, outputs, batch, batch_idx, epoch=trainer.current_epoch)
 
 
 class PlotSample(BasePlotCallback):

--- a/src/anemoi/training/diagnostics/plots.py
+++ b/src/anemoi/training/diagnostics/plots.py
@@ -291,8 +291,9 @@ def plot_histogram(
 
         # Visualization trick for tp
         if variable_name in {"tp", "cp"}:
-            hist_yt *= bins_yt[:-1]
-            hist_yp *= bins_yp[:-1]
+            # in-place multiplication does not work here because variables are different numpy types
+            hist_yt = hist_yt * bins_yt[:-1]
+            hist_yp = hist_yp * bins_yp[:-1]
         # Plot the modified histogram
         ax[plot_idx].bar(bins_yt[:-1], hist_yt, width=np.diff(bins_yt), color="blue", alpha=0.7, label="Truth (ERA5)")
         ax[plot_idx].bar(bins_yp[:-1], hist_yp, width=np.diff(bins_yp), color="red", alpha=0.7, label="Anemoi")


### PR DESCRIPTION
Two minor errors in the callback plot functions produced errors when enabling the plots. This PR incorporates the fixes
- in the histogram plot a multiplication needs to be done out-of-place
- one call of self.plot was missing a variable

Plotting is now possible: [mlflow](https://mlflow.copernicus-climate.eu/#/experiments/81/runs/46b8f692bfb34888a60fe9019bb6ad26)