### PR TITLE
pin numpy <2 until tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Keep it human-readable, your future self will thank you!
  - Bumped versions in Pre-commit hooks
  - Fix crash when logging hyperparameters with missing values in the config
  - Fixed "null" tracker metadata when tracking is disabled, now returns an empty dict
+ - Pinned numpy<2 until we can test all migration
 
 ### Removed
  - Dependency on mlflow-export-import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@
 # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 
 [build-system]
-requires = [ "setuptools>=60", "setuptools-scm>=8" ]
+requires = ["setuptools>=60", "setuptools-scm>=8"]
 
 [project]
 name = "anemoi-training"
 
 description = "A package to hold various functions to support training of ML models."
-keywords = [ "ai", "tools", "training" ]
+keywords = ["ai", "tools", "training"]
 
 license = { file = "LICENSE" }
 authors = [
@@ -39,7 +39,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-dynamic = [ "version" ]
+dynamic = ["version"]
 
 dependencies = [
   "anemoi-datasets>=0.4",
@@ -50,6 +50,7 @@ dependencies = [
   "hydra-core>=1.3",
   "matplotlib>=3.7.1",
   "mlflow>=2.11.1",
+  "numpy<2",                          # Pinned until we can confirm it works with anemoi graphs
   "pynvml>=11.5",
   "pyshtools>=4.10.4",
   "pytorch-lightning>=2.1",
@@ -61,7 +62,7 @@ dependencies = [
   "zarr>=2.14.2",
 ]
 
-optional-dependencies.all = [  ]
+optional-dependencies.all = []
 
 optional-dependencies.dev = [
   "anemoi-training[docs,tests,all]",
@@ -75,7 +76,7 @@ optional-dependencies.docs = [
   "sphinx-argparse",
   "sphinx-rtd-theme",
 ]
-optional-dependencies.tests = [ "pytest", "pytest-mock" ]
+optional-dependencies.tests = ["pytest", "pytest-mock"]
 
 urls.Changelog = "https://github.com/ecmwf/anemoi-training/CHANGELOG.md"
 urls.Documentation = "https://anemoi-training.readthedocs.io/"
@@ -91,8 +92,8 @@ version_file = "src/anemoi/training/_version.py"
 [tool.ruff]
 target-version = "py39"
 line-length = 120
-src = [ "src" ]
-exclude = [ "docs/" ]
+src = ["src"]
+exclude = ["docs/"]
 
 preview = true
 lint.flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@
 # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 
 [build-system]
-requires = ["setuptools>=60", "setuptools-scm>=8"]
+requires = [ "setuptools>=60", "setuptools-scm>=8" ]
 
 [project]
 name = "anemoi-training"
 
 description = "A package to hold various functions to support training of ML models."
-keywords = ["ai", "tools", "training"]
+keywords = [ "ai", "tools", "training" ]
 
 license = { file = "LICENSE" }
 authors = [
@@ -39,7 +39,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-dynamic = ["version"]
+dynamic = [ "version" ]
 
 dependencies = [
   "anemoi-datasets>=0.4",
@@ -62,7 +62,7 @@ dependencies = [
   "zarr>=2.14.2",
 ]
 
-optional-dependencies.all = []
+optional-dependencies.all = [  ]
 
 optional-dependencies.dev = [
   "anemoi-training[docs,tests,all]",
@@ -76,7 +76,7 @@ optional-dependencies.docs = [
   "sphinx-argparse",
   "sphinx-rtd-theme",
 ]
-optional-dependencies.tests = ["pytest", "pytest-mock"]
+optional-dependencies.tests = [ "pytest", "pytest-mock" ]
 
 urls.Changelog = "https://github.com/ecmwf/anemoi-training/CHANGELOG.md"
 urls.Documentation = "https://anemoi-training.readthedocs.io/"
@@ -92,8 +92,8 @@ version_file = "src/anemoi/training/_version.py"
 [tool.ruff]
 target-version = "py39"
 line-length = 120
-src = ["src"]
-exclude = ["docs/"]
+src = [ "src" ]
+exclude = [ "docs/" ]
 
 preview = true
 lint.flake8-import-conventions.extend-aliases."pytorch_lightning" = "pl"


### PR DESCRIPTION
Numpy is in v2 now and we're already getting the first problems. This pins the version <2 until we can confirm it works.