### PR TITLE
fix: remove len calculation in iterable dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Keep it human-readable, your future self will thank you!
 ### Removed
  - Dependency on mlflow-export-import
  - Specific user configs
+ - __len__ function of NativeGridDataset as it lead to bugs
 
 <!-- Add Git Diffs for Links above -->
 

--- a/src/anemoi/training/data/dataset.py
+++ b/src/anemoi/training/data/dataset.py
@@ -224,16 +224,6 @@ class NativeGridDataset(IterableDataset):
 
             yield torch.from_numpy(x)
 
-    def __len__(self) -> int:
-        # Total number of valid ICs is dataset length minus rollout minus additional multistep inputs
-        len_corrected = len(self.data) - (self.rollout + (self.multi_step - 1)) * self.timeincrement
-
-        # Divide this equally across shards (one shard per group!)
-        shard_size = len_corrected // self.model_comm_num_groups
-        shard_start = self.model_comm_group_id * shard_size + (self.multi_step - 1) * self.timeincrement
-        shard_end = min((self.model_comm_group_id + 1) * shard_size, len(self.data) - self.rollout * self.timeincrement)
-        return shard_end - shard_start
-
     def __repr__(self) -> str:
         return f"""
             {super().__repr__()}


### PR DESCRIPTION
Fix.

**Bug**
- In some cases, the self-implemented __len__ property on the NativeGridDataset Class does not return the same number of samples that would be equivalent to that implied by the per_worker_init
- In these cases this leads to things such as validation loop skipped, Hanging at end of a training epoch

**To Reproduce**
The example has the following setup:
- multiple GPU
- no limit on the training batches: `dataloader.limit_batches.training: null`
-> validation epoch is skipped.
- deleting the __len__ function solves this issue

Example of behaviour here: https://mlflow.copernicus-climate.eu/#/compare-runs?runs=%5B%22ab15907c4d5a45dd89a9c708eaea3dbf%22,%22dfb1bfa2d72e49769e28a5a138321006%22,%228731ff0d85bf40cbbe7f313fa22af005%22%5D&experiments=%5B%2281%22%5D

**Additional context**
We don't have any functionality built on top of this function so deleting it is the easiest solution to remove the bug.  
We are considering options to use a dataset class that allows us to calculate/obtain the length of the dataset.

Possible Reviewers:
@Rilwan-Adewoyin
