### PR TITLE
Define common paths ignore for downstream CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,29 @@
 name: ci
 
 on:
-  # Trigger the workflow on push to master or develop, except tag creation
+  # Trigger the workflow on push to main or develop, except tag creation
   push:
     branches:
       - 'main'
       - 'develop'
     tags-ignore:
       - '**'
-    paths:
-      - "src/**"
-      - "tests/**"
+    paths-ignore: &paths-ignore
+      - "docs/**"
+      - "CHANGELOG.md"
+      - "README.md"
 
   # Trigger the workflow on pull request
-  pull_request: ~
+  pull_request:
+    paths-ignore: *paths-ignore
 
-  # Trigger the workflow manuallyp instals
+  # Trigger the workflow manually
   workflow_dispatch: ~
 
   # Trigger after public PR approved for CI
   pull_request_target:
     types: [labeled]
+    paths-ignore: *paths-ignore
 
 jobs:
   # Run CI including downstream packages on self-hosted runners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Keep it human-readable, your future self will thank you!
  - Fix crash when logging hyperparameters with missing values in the config
  - Fixed "null" tracker metadata when tracking is disabled, now returns an empty dict
  - Pinned numpy<2 until we can test all migration
+ - (ci): path ignore of docs for downstream ci
 
 ### Removed
  - Dependency on mlflow-export-import


### PR DESCRIPTION
This is to limit the runs of downstream ci for pure documentation changes in all triggers using yaml aliases.