### PR TITLE
Add a slurm hardware config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,62 +13,72 @@ Keep it human-readable, your future self will thank you!
 ### Added
 
 #### Subcommands
- - Subcommand for training `anemoi-training train`
- - Subcommand for config generation of configs
- - Subcommand for mlflow: login and sync
- - Subcommand for checkpoint handling
+
+-   Subcommand for training `anemoi-training train`
+-   Subcommand for config generation of configs
+-   Subcommand for mlflow: login and sync
+-   Subcommand for checkpoint handling
 
 #### Functionality
- - Searchpaths for Hydra configs, to enable configs in CWD, `ANEMOI_CONFIG_PATH` env, and `.config/anemoi/training` in addition to package defaults
- - MlFlow token authentication
- - Configurable pressure level scaling
+
+-   Searchpaths for Hydra configs, to enable configs in CWD, `ANEMOI_CONFIG_PATH` env, and `.config/anemoi/training` in addition to package defaults
+-   MlFlow token authentication
+-   Configurable pressure level scaling
 
 #### Continuous Integration / Deployment
- - Downstream CI to test all dependencies with changes
- - Changelog Status check
- - Readthedocs PR builder
- - Changelog Release Updater Workflow
+
+-   Downstream CI to test all dependencies with changes
+-   Changelog Status check
+-   Readthedocs PR builder
+-   Changelog Release Updater Workflow
 
 #### Miscellaneous
- - Extended ruff Ruleset
- - Added Docsig pre-commit hook
- - `__future__` annotations for typehints
- - Added Typehints where missing
- - Added Changelog
- - Correct errors in callback plots
- - fix error in the default config
+
+-   Extended ruff Ruleset
+-   Added Docsig pre-commit hook
+-   `__future__` annotations for typehints
+-   Added Typehints where missing
+-   Added Changelog
+-   Correct errors in callback plots
+-   fix error in the default config
+-   example slurm config
 
 ### Changed
 
 #### Move to Anemoi Ecosystem
- - Fixed PyPI packaging
- - Use of Anemoi models
- - Use of Anemoi graphs
- - Adjusted tests to work with new Anemoi ecosystem
- - Adjusted configs to reasonable common defaults
+
+-   Fixed PyPI packaging
+-   Use of Anemoi models
+-   Use of Anemoi graphs
+-   Adjusted tests to work with new Anemoi ecosystem
+-   Adjusted configs to reasonable common defaults
 
 #### Functionality
- - Changed hardware-specific keys from configs to `???` to trigger "missing"
- - `__len__` of NativeGridDataset
- - Configurable dropout in attention layer
+
+-   Changed hardware-specific keys from configs to `???` to trigger "missing"
+-   `__len__` of NativeGridDataset
+-   Configurable dropout in attention layer
 
 #### Docs
- - Fixed docstrings
+
+-   Fixed docstrings
 
 #### Miscellaneous
- - Moved callbacks into folder to fascilitate future refactor
- - Adjusted PyPI release infrastructure to common ECMWF workflow
- - Bumped versions in Pre-commit hooks
- - Fix crash when logging hyperparameters with missing values in the config
- - Fixed "null" tracker metadata when tracking is disabled, now returns an empty dict
- - Pinned numpy<2 until we can test all migration
- - (ci): path ignore of docs for downstream ci
- - (ci): remove yaml anchor, unsupported by Github
+
+-   Moved callbacks into folder to fascilitate future refactor
+-   Adjusted PyPI release infrastructure to common ECMWF workflow
+-   Bumped versions in Pre-commit hooks
+-   Fix crash when logging hyperparameters with missing values in the config
+-   Fixed "null" tracker metadata when tracking is disabled, now returns an empty dict
+-   Pinned numpy<2 until we can test all migration
+-   (ci): path ignore of docs for downstream ci
+-   (ci): remove yaml anchor, unsupported by Github
 
 ### Removed
- - Dependency on mlflow-export-import
- - Specific user configs
- - __len__ function of NativeGridDataset as it lead to bugs
+
+-   Dependency on mlflow-export-import
+-   Specific user configs
+-   **len** function of NativeGridDataset as it lead to bugs
 
 <!-- Add Git Diffs for Links above -->
 

--- a/src/anemoi/training/config/hardware/slurm.yaml
+++ b/src/anemoi/training/config/hardware/slurm.yaml
@@ -1,0 +1,10 @@
+---
+defaults:
+- paths: example
+- files: example
+
+# number of GPUs per node and number of nodes (for DDP)
+accelerator: auto
+num_gpus_per_node: ${oc.decode:${oc.env:SLURM_GPUS_PER_NODE}}
+num_nodes: ${oc.decode:${oc.env:SLURM_NNODES}}
+num_gpus_per_model: 1


### PR DESCRIPTION
This provides an example how hydra can use environment variables to read from and provides SLURM batch job env variables to derive the correct number of GPUs and nodes.