### PR TITLE
fix: saving frequency bug for inference checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Keep it human-readable, your future self will thank you!
 
 - Enable the callback for plotting a histogram for variables containing NaNs
 - Enforce same binning for histograms comparing true data to predicted data
+- Fix: Inference checkpoints are now saved according the frequency settings defined in the config
 
 ## [0.1.0 - Anemoi training - First release](https://github.com/ecmwf/anemoi-training/compare/x.x.x...0.1.0) - 2024-08-16
 

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -818,7 +818,7 @@ class AnemoiCheckpoint(ModelCheckpoint):
 
     def _remove_checkpoint(self, trainer: "pl.Trainer", filepath: str) -> None:
         """Calls the strategy to remove the checkpoint file."""
-        trainer.strategy.remove_checkpoint(filepath)
+        super()._remove_checkpoint(trainer, filepath)
         trainer.strategy.remove_checkpoint(self._get_inference_checkpoint_filepath(filepath))
 
     def _get_inference_checkpoint_filepath(self, filepath: str) -> str:


### PR DESCRIPTION
## Describe your changes
Current `AnemoiCheckpoint` allows to save the training and inference checkpoint with just one object by defining a custom `_save_checkpoint `method to handle this. However we also need to overwrite the `_remove_checkpoint` method to handle the removal of both training and inference checkpoint according to the settings defined in the eval_rollout.yaml config

**Please also include relevant motivation and context.**
PR is associated to this issue https://github.com/ecmwf-lab/aifs-mono/issues/257


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue ticket number and link
Ticket number  - 257
https://github.com/ecmwf-lab/aifs-mono/issues/257


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation and docstrings to reflect the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have ensured that the code is still pip-installable after the changes and runs
- [X] I have not introduced new dependencies in the inference partion of the model
- [X] I have ran this on single GPU
- [X] I have ran this on multi-GPU or multi-node
- [ ] I have ran this to work on LUMI (or made sure the changes work independently.)
- [ ] I have ran the Benchmark Profiler against the old version of the code

## Tag possible reviewers
You can @-tag people to review this PR in addition to formal review requests.