### PR TITLE
Fix - `datetime.timedelta` to string conversion for JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Keep it human-readable, your future self will thank you!
 
 ### Fixed
 
-- Fix `TypeError` raised when trying to JSON serialise `datetime.timedelta` object
+- Fix `TypeError` raised when trying to JSON serialise `datetime.timedelta` object - [#43](https://github.com/ecmwf/anemoi-training/pull/43)
 
 ## [0.1.0 - Anemoi training - First release](https://github.com/ecmwf/anemoi-training/compare/x.x.x...0.1.0) - 2024-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Keep it human-readable, your future self will thank you!
 - Enforce same binning for histograms comparing true data to predicted data
 - Fix: Inference checkpoints are now saved according the frequency settings defined in the config
 
+### Fixed
+
+- Fix `TypeError` raised when trying to JSON serialise `datetime.timedelta` object
+
 ## [0.1.0 - Anemoi training - First release](https://github.com/ecmwf/anemoi-training/compare/x.x.x...0.1.0) - 2024-08-16
 
 ### Added

--- a/src/anemoi/training/utils/jsonify.py
+++ b/src/anemoi/training/utils/jsonify.py
@@ -10,10 +10,10 @@ import datetime
 from pathlib import Path
 
 import torch
-from anemoi.utils.dates import frequency_to_string
 from anemoi.models.data_indices.collection import BaseIndex
 from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.models.data_indices.tensor import BaseTensorIndex
+from anemoi.utils.dates import frequency_to_string
 from omegaconf import DictConfig
 from omegaconf import ListConfig
 from omegaconf import OmegaConf

--- a/src/anemoi/training/utils/jsonify.py
+++ b/src/anemoi/training/utils/jsonify.py
@@ -10,6 +10,7 @@ import datetime
 from pathlib import Path
 
 import torch
+from anemoi.utils.dates import frequency_to_string
 from anemoi.models.data_indices.collection import BaseIndex
 from anemoi.models.data_indices.collection import IndexCollection
 from anemoi.models.data_indices.tensor import BaseTensorIndex
@@ -44,6 +45,8 @@ def map_config_to_primitives(config: OmegaConf) -> dict:
         config = str(config)
     elif isinstance(config, datetime.date):
         config = config.isoformat()
+    elif isinstance(config, datetime.timedelta):
+        config = frequency_to_string(config)
     elif isinstance(config, (list, tuple)):
         config = [map_config_to_primitives(v) for v in config]
     elif isinstance(config, dict):


### PR DESCRIPTION
This adds the conversion of a `datetime.timedelta` used for the frequency to a string for JSON serialisation.

Closes #42 