### PR TITLE
Expanded intro docs and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Keep it human-readable, your future self will thank you!
 - Enforce same binning for histograms comparing true data to predicted data
 - Fix: Inference checkpoints are now saved according the frequency settings defined in the config
 
+### Changed
+
+- Updated configuration examples in documentation and corrected links - [#46](https://github.com/ecmwf/anemoi-training/pull/46)
+
 ## [0.1.0 - Anemoi training - First release](https://github.com/ecmwf/anemoi-training/compare/x.x.x...0.1.0) - 2024-08-16
 
 ### Added

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinxarg.ext",
+    "sphinx.ext.autosectionlabel",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/start/hydra-intro.rst
+++ b/docs/start/hydra-intro.rst
@@ -55,7 +55,7 @@ config is in the hardware folder. The model config is in the model
 folder.
 
 You will need to specify the location of your anemoi dataset in the
-hardware paths and files. These contain ``???``` as placeholders.
+hardware paths and files. These contain ``???`` as placeholders.
 
 Anemoi training provides two default configurations ``config.yaml`` and
 ``debug.yaml``. The first is a generic config file, while the second is
@@ -74,13 +74,15 @@ added to the training command like so:
 
 The following missing config options which must be overridden by users:
 
--  ``hardware.files``: Name of datasets used for training.
 -  ``hardware.paths.data``: Location of base directory where datasets
    are stored
+
+-  ``hardware.paths.graph``: Location of graph directory
+
 -  ``hardware.paths.output``: Location of output directory
 
-Optionally, you can also override the following:
+-  ``hardware.files.dataset``: Filename(s) of datasets used for training
 
 -  ``hardware.files.graph``: If you have pre-computed a specific graph,
-   specify this here. Otherwise, a new graph will be constructed on the
-   fly.
+   specify its filename here. Otherwise, a new graph will be constructed
+   on the fly and written to the filename given.

--- a/docs/start/training-your-first-model.rst
+++ b/docs/start/training-your-first-model.rst
@@ -14,10 +14,12 @@ The training script will intentionally crash as it does not know where
 your data is stored.
 
 These missing values in the configuration are placeholders for the user
-to fill in marked with `???`. You can find the default configurations in
-the `anemoi-training` repository under `src/anemoi/training/configs/`.
-Alternatively, the next section will show you how to `generate a user
-config file <hydra-intro>`_.
+to fill in marked with ``???``. You can find the default configurations
+in the `Anemoi Training repository
+<https://github.com/ecmwf/anemoi-training>`_ under
+``src/anemoi/training/config/``. Alternatively, the next section will
+show you how to :ref:`generate a user config file <Configuring the
+Training>`.
 
 *******************************
  Preparing training components
@@ -25,13 +27,13 @@ config file <hydra-intro>`_.
 
 Anemoi Training requires two primary components to get started:
 
-#. **Graph Definition from `Anemoi Graphs
-   <https://anemoi-graphs.readthedocs.org>`_:** This defines the
-   structure of your machine learning model, including the layers,
-   connections, and operations that will be used during training.
+#. **Graph Definition** from `Anemoi Graphs
+   <https://anemoi-graphs.readthedocs.org>`_: This defines the structure
+   of your machine learning model, including the layers, connections,
+   and operations that will be used during training.
 
-#. **Dataset from `Anemoi Datasets
-   <https://anemoi-datasets.readthedocs.org>`_:** This provides the
+#. **Dataset** from `Anemoi Datasets
+   <https://anemoi-datasets.readthedocs.org>`_ : This provides the
    training data that will be fed into the model. The dataset should be
    pre-processed and formatted according to the specifications of the
    Anemoi Datasets module.

--- a/docs/user-guide/configuring.rst
+++ b/docs/user-guide/configuring.rst
@@ -103,7 +103,7 @@ match the dataset you provide.
    - diagnostics: eval_rollout
    - hardware: example
    - graph: multi_scale
-   - model: transformer
+   - model: transformer # Change from default group
    - training: default
    - _self_
 
@@ -127,7 +127,7 @@ match the dataset you provide.
 When we save this `example.yaml` file, we can run the training with this
 config using:
 
-.. code:: console
+.. code:: bash
 
    anemoi-training train --config-name=example.yaml
 

--- a/docs/user-guide/configuring.rst
+++ b/docs/user-guide/configuring.rst
@@ -80,7 +80,20 @@ Example Config File
 ===================
 
 Here is an example of a config file that changes the model to a
-transformer, the learning rate to 1e-3, and the number of GPUs to 1:
+transformer, the learning rate to 1e-3, and the number of GPUs to 1. We
+also need to specify the paths to the data, output, and graph data and
+give the names of the files to use. You can get a dataset from the
+`Anemoi Datasets catalogue <https://anemoi.ecmwf.int/>`_ or create one
+using the `Anemoi Datasets
+<https://anemoi-datasets.readthedocs.io/en/latest/>`_ package.
+
+You can create a graph using `Anemoi Graphs
+<https://anemoi-graphs.readthedocs.io/en/latest/>`_ or one will be
+created for you at runtime. Note that you must specify a filename for
+the graph, here we use `first_graph_m320.pt`.
+
+You'll also notice we've specified a resolution for the data, this must
+match the dataset you provide.
 
 .. code:: yaml
 
@@ -90,12 +103,22 @@ transformer, the learning rate to 1e-3, and the number of GPUs to 1:
    - diagnostics: eval_rollout
    - hardware: example
    - graph: multi_scale
-   - model: transformer # Change from default group
+   - model: transformer
    - training: default
    - _self_
 
+   data:
+      resolution: n320
+
    hardware:
       num_gpus_per_node: 1
+      paths:
+         output: /home/username/anemoi/training/output
+         data: /home/username/anemoi/datasets
+         graph: /home/username/anemoi/training/graphs
+      files:
+         dataset: datset-n320-2019-2021-6h.zarr
+         graph: first_graph_m320.pt
 
    training:
       lr:
@@ -104,7 +127,7 @@ transformer, the learning rate to 1e-3, and the number of GPUs to 1:
 When we save this `example.yaml` file, we can run the training with this
 config using:
 
-.. code:: bash
+.. code:: console
 
    anemoi-training train --config-name=example.yaml
 

--- a/docs/user-guide/configuring.rst
+++ b/docs/user-guide/configuring.rst
@@ -118,7 +118,7 @@ match the dataset you provide.
          graph: /home/username/anemoi/training/graphs
       files:
          dataset: datset-n320-2019-2021-6h.zarr
-         graph: first_graph_m320.pt
+         graph: first_graph_n320.pt
 
    training:
       lr:


### PR DESCRIPTION
After working through the documentation to get a simple training run going I encountered some issues with the docs.
This PR:

- fixes some broken links to the other anemoi repos
- updates some text on required overrides in the config
- updates the example config file with what's needed for a run (hopefully)

 

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--46.org.readthedocs.build/en/46/

<!-- readthedocs-preview anemoi-training end -->