### PR TITLE
Authentication support for mlflow sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Keep it human-readable, your future self will thank you!
 - Enforce same binning for histograms comparing true data to predicted data
 - Fix: Inference checkpoints are now saved according the frequency settings defined in the config
 - Feature: Add configurable models [#50](https://github.com/ecmwf/anemoi-training/pulls/50)
+- Feature: Authentication support for mlflow sync
 
 ## [0.1.0 - Anemoi training - First release](https://github.com/ecmwf/anemoi-training/releases/tag/0.1.0) - 2024-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Keep it human-readable, your future self will thank you!
 - Enforce same binning for histograms comparing true data to predicted data
 - Fix: Inference checkpoints are now saved according the frequency settings defined in the config [#37](https://github.com/ecmwf/anemoi-training/pull/37)
 - Feature: Add configurable models [#50](https://github.com/ecmwf/anemoi-training/pulls/50)
+- Feature: Authentication support for mlflow sync - [#51](https://github.com/ecmwf/anemoi-training/pull/51)
 - Feature: Support training for datasets with missing time steps [#48](https://github.com/ecmwf/anemoi-training/pulls/48)
 
 ### Fixed
@@ -34,7 +35,6 @@ Keep it human-readable, your future self will thank you!
 ### Changed
 
 - Updated configuration examples in documentation and corrected links - [#46](https://github.com/ecmwf/anemoi-training/pull/46)
-- Feature: Authentication support for mlflow sync
 
 ## [0.1.0 - Anemoi training - First release](https://github.com/ecmwf/anemoi-training/releases/tag/0.1.0) - 2024-08-16
 

--- a/src/anemoi/training/commands/mlflow.py
+++ b/src/anemoi/training/commands/mlflow.py
@@ -63,6 +63,13 @@ class MlFlow(Command):
             default="anemoi-debug",
         )
         sync.add_argument(
+            "--authentication",
+            "-a",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="The destination server requires authentication.",
+        )
+        sync.add_argument(
             "--export-deleted-runs",
             "-x",
             action="store_true",
@@ -89,6 +96,13 @@ class MlFlow(Command):
 
         if args.subcommand == "sync":
             from anemoi.training.utils.mlflow_sync import MlFlowSync
+
+            if args.authentication:
+                from anemoi.training.diagnostics.mlflow.auth import TokenAuth
+
+                auth = TokenAuth(url=args.destination)
+                auth.login()
+                auth.authenticate()
 
             log_level = "DEBUG" if args.verbose else "INFO"
 

--- a/src/anemoi/training/commands/mlflow.py
+++ b/src/anemoi/training/commands/mlflow.py
@@ -104,6 +104,7 @@ class MlFlow(Command):
             return
 
         if args.subcommand == "sync":
+            from anemoi.training.diagnostics.mlflow import health_check
             from anemoi.training.utils.mlflow_sync import MlFlowSync
 
             if args.authentication:
@@ -112,6 +113,8 @@ class MlFlow(Command):
                 auth = TokenAuth(url=args.destination)
                 auth.login()
                 auth.authenticate()
+
+            health_check(args.destination)
 
             log_level = "DEBUG" if args.verbose else "INFO"
 

--- a/src/anemoi/training/commands/mlflow.py
+++ b/src/anemoi/training/commands/mlflow.py
@@ -45,6 +45,7 @@ class MlFlow(Command):
             "--source",
             "-s",
             help="The MLflow logs source directory.",
+            metavar="DIR",
             required=True,
             default=argparse.SUPPRESS,
         )
@@ -52,22 +53,31 @@ class MlFlow(Command):
             "--destination",
             "-d",
             help="The destination MLflow tracking URI.",
+            metavar="URI",
             required=True,
             default=argparse.SUPPRESS,
         )
-        sync.add_argument("--run-id", "-r", help="The run ID to sync.", required=True, default=argparse.SUPPRESS)
+        sync.add_argument(
+            "--run-id",
+            "-r",
+            help="The run ID to sync.",
+            metavar="ID",
+            required=True,
+            default=argparse.SUPPRESS,
+        )
         sync.add_argument(
             "--experiment-name",
             "-e",
             help="The experiment name to sync to.",
+            metavar="NAME",
             default="anemoi-debug",
         )
         sync.add_argument(
             "--authentication",
             "-a",
             action="store_true",
-            default=argparse.SUPPRESS,
             help="The destination server requires authentication.",
+            default=argparse.SUPPRESS,
         )
         sync.add_argument(
             "--export-deleted-runs",

--- a/src/anemoi/training/commands/mlflow.py
+++ b/src/anemoi/training/commands/mlflow.py
@@ -104,7 +104,7 @@ class MlFlow(Command):
             return
 
         if args.subcommand == "sync":
-            from anemoi.training.diagnostics.mlflow import health_check
+            from anemoi.training.diagnostics.mlflow.utils import health_check
             from anemoi.training.utils.mlflow_sync import MlFlowSync
 
             if args.authentication:

--- a/src/anemoi/training/commands/mlflow.py
+++ b/src/anemoi/training/commands/mlflow.py
@@ -77,7 +77,6 @@ class MlFlow(Command):
             "-a",
             action="store_true",
             help="The destination server requires authentication.",
-            default=argparse.SUPPRESS,
         )
         sync.add_argument(
             "--export-deleted-runs",

--- a/src/anemoi/training/diagnostics/mlflow/__init__.py
+++ b/src/anemoi/training/diagnostics/mlflow/__init__.py
@@ -4,32 +4,3 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-
-import os
-
-import requests
-
-
-def health_check(tracking_uri: str) -> None:
-    """Query the health endpoint of an MLflow server.
-
-    If the server is not reachable, raise an error and remind the user that authentication may be required.
-
-    Raises
-    ------
-    ConnectionError
-        If the server is not reachable.
-
-    """
-    token = os.getenv("MLFLOW_TRACKING_TOKEN")
-
-    headers = {"Authorization": f"Bearer {token}"}
-    response = requests.get(f"{tracking_uri}/health", headers=headers, timeout=60)
-
-    if response.text == "OK":
-        return
-
-    error_msg = f"Could not connect to MLflow server at {tracking_uri}. "
-    if not token:
-        error_msg += "The server may require authentication, did you forget to turn it on?"
-    raise ConnectionError(error_msg)

--- a/src/anemoi/training/diagnostics/mlflow/__init__.py
+++ b/src/anemoi/training/diagnostics/mlflow/__init__.py
@@ -4,3 +4,32 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+
+import os
+
+import requests
+
+
+def health_check(tracking_uri: str) -> None:
+    """Query the health endpoint of an MLflow server.
+
+    If the server is not reachable, raise an error and remind the user that authentication may be required.
+
+    Raises
+    ------
+    ConnectionError
+        If the server is not reachable.
+
+    """
+    token = os.getenv("MLFLOW_TRACKING_TOKEN")
+
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(f"{tracking_uri}/health", headers=headers, timeout=60)
+
+    if response.text == "OK":
+        return
+
+    error_msg = f"Could not connect to MLflow server at {tracking_uri}. "
+    if not token:
+        error_msg += "The server may require authentication, did you forget to turn it on in the config?"
+    raise ConnectionError(error_msg)

--- a/src/anemoi/training/diagnostics/mlflow/__init__.py
+++ b/src/anemoi/training/diagnostics/mlflow/__init__.py
@@ -31,5 +31,5 @@ def health_check(tracking_uri: str) -> None:
 
     error_msg = f"Could not connect to MLflow server at {tracking_uri}. "
     if not token:
-        error_msg += "The server may require authentication, did you forget to turn it on in the config?"
+        error_msg += "The server may require authentication, did you forget to turn it on?"
     raise ConnectionError(error_msg)

--- a/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -25,8 +25,8 @@ from pytorch_lightning.loggers.mlflow import _convert_params
 from pytorch_lightning.loggers.mlflow import _flatten_dict
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
-from anemoi.training.diagnostics.mlflow import health_check
 from anemoi.training.diagnostics.mlflow.auth import TokenAuth
+from anemoi.training.diagnostics.mlflow.utils import health_check
 from anemoi.training.utils.jsonify import map_config_to_primitives
 
 if TYPE_CHECKING:

--- a/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -20,12 +20,12 @@ from typing import Any
 from typing import Literal
 from weakref import WeakValueDictionary
 
-import requests
 from pytorch_lightning.loggers.mlflow import MLFlowLogger
 from pytorch_lightning.loggers.mlflow import _convert_params
 from pytorch_lightning.loggers.mlflow import _flatten_dict
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
+from anemoi.training.diagnostics.mlflow import health_check
 from anemoi.training.diagnostics.mlflow.auth import TokenAuth
 from anemoi.training.utils.jsonify import map_config_to_primitives
 
@@ -35,31 +35,6 @@ if TYPE_CHECKING:
     from omegaconf import OmegaConf
 
 LOGGER = logging.getLogger(__name__)
-
-
-def health_check(tracking_uri: str) -> None:
-    """Query the health endpoint of an MLflow server.
-
-    If the server is not reachable, raise an error and remind the user that authentication may be required.
-
-    Raises
-    ------
-    ConnectionError
-        If the server is not reachable.
-
-    """
-    token = os.getenv("MLFLOW_TRACKING_TOKEN")
-
-    headers = {"Authorization": f"Bearer {token}"}
-    response = requests.get(f"{tracking_uri}/health", headers=headers, timeout=60)
-
-    if response.text == "OK":
-        return
-
-    error_msg = f"Could not connect to MLflow server at {tracking_uri}. "
-    if not token:
-        error_msg += "The server may require authentication, did you forget to turn it on in the config?"
-    raise ConnectionError(error_msg)
 
 
 def get_mlflow_run_params(config: OmegaConf, tracking_uri: str) -> tuple[str | None, str, dict[str, Any]]:

--- a/src/anemoi/training/diagnostics/mlflow/utils.py
+++ b/src/anemoi/training/diagnostics/mlflow/utils.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2024 European Centre for Medium-Range Weather Forecasts.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import os
+
+import requests
+
+
+def health_check(tracking_uri: str) -> None:
+    """Query the health endpoint of an MLflow server.
+
+    If the server is not reachable, raise an error and remind the user that authentication may be required.
+
+    Raises
+    ------
+    ConnectionError
+        If the server is not reachable.
+
+    """
+    token = os.getenv("MLFLOW_TRACKING_TOKEN")
+
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(f"{tracking_uri}/health", headers=headers, timeout=60)
+
+    if response.text == "OK":
+        return
+
+    error_msg = f"Could not connect to MLflow server at {tracking_uri}. "
+    if not token:
+        error_msg += "The server may require authentication, did you forget to turn it on?"
+    raise ConnectionError(error_msg)

--- a/src/anemoi/training/utils/mlflow_sync.py
+++ b/src/anemoi/training/utils/mlflow_sync.py
@@ -49,7 +49,7 @@ try:
     from mlflow_export_import.run.run_data_importer import _log_metrics
     from mlflow_export_import.run.run_data_importer import _log_params
 except ImportError:
-    msg = "The 'mlflow_export_import' package is not installed. Please install it from https://github.com/mlflow/mlflow-export-import"
+    msg = "The 'mlflow-export-import' package is not installed. Please install it from https://github.com/mlflow/mlflow-export-import"
     raise ImportError(msg) from None
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Adds the `--authentication (-a)` option to the `mlflow sync` subcommand. This enables authentication on the destination server. It retrieves a token and sets it for the mlflow API to use during sync.

Tested the following: local logs -> new server, and old server -> new server (the latter only works from Atos).

Todo: test from Leonardo.

Usage:

`anemoi-training mlflow sync -s /path/to/logs -d https://mlflow.server -r 1234 -e sync-test -a`