### PR TITLE
fix: remapped variables in tests need to be dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Keep it human-readable, your future self will thank you!
 
 #### Miscellaneous
 
-- Introduction of remapper to anemoi-models leads to changes in the data indices and some preprocessors cannot be applied in-place anymore.
+- Introduction of remapper to anemoi-models leads to changes in the data indices. Some preprocessors cannot be applied in-place anymore.
 
 #### Functionality
 

--- a/tests/train/test_loss_scaling.py
+++ b/tests/train/test_loss_scaling.py
@@ -21,11 +21,9 @@ def fake_data(request: SubRequest) -> tuple[DictConfig, IndexCollection]:
             "data": {
                 "forcing": ["x"],
                 "diagnostic": ["z", "q"],
-                "remapped": [
-                    {
-                        "d": ["cos_d", "sin_d"],
-                    },
-                ],
+                "remapped": {
+                    "d": ["cos_d", "sin_d"],
+                },
             },
             "training": {
                 "loss_scaling": {


### PR DESCRIPTION
Tests: remapped variables need to be dictionary