### PR TITLE
Update learning rate schedule in training/default.yaml

### DIFF
--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -48,9 +48,9 @@ rollout:
 
 max_epochs: 200
 lr:
-  rate: 0.625e-4 #local_lr
-  iterations: 300000
-  min: 3e-7 #Not scaled by #GPU
+  rate: 5e-4 #local_lr
+  iterations: 150000
+  min: 2.4e-6 #Not scaled by #GPU
 
 # Changes in per-gpu batch_size should come with a rescaling of the local_lr
 # in order to keep a constant global_lr


### PR DESCRIPTION
This updates the default values for the learning rate schedule. Specifically, the local learning rate is increased to 8x the original learning rate. In addition, the number of iterations is reduced from 300k to 150k. This has led to similar accuracy in stretched grid experiments using the graph transformer architecture, while requiring only 50% of the GPU compute. Optimised default values could save GPU resources across the Pilot Project.

Suggested review questions:
- Are these settings also an enhancement for global / LAM models? (tested only for stretched grid)
- Are these settings also an enhancement for GNN / transformer models? (tested only for graph transformer architecture)