### PR TITLE
Fix mlflow command on python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Keep it human-readable, your future self will thank you!
 
 - Fix `TypeError` raised when trying to JSON serialise `datetime.timedelta` object - [#43](https://github.com/ecmwf/anemoi-training/pull/43)
 - Bugfixes for CI (#56)
+- Fix `mlflow` subcommand on python 3.9 [#62](https://github.com/ecmwf/anemoi-training/pull/62)
 - Show correct subcommand in MLFlow - Addresses [#39](https://github.com/ecmwf/anemoi-training/issues/39) in [#61](https://github.com/ecmwf/anemoi-training/pull/61)
 
 ### Changed

--- a/src/anemoi/training/diagnostics/mlflow/auth.py
+++ b/src/anemoi/training/diagnostics/mlflow/auth.py
@@ -75,20 +75,8 @@ class TokenAuth:
     def load_config() -> dict:
         return load_config(TokenAuth.config_file)
 
-    @staticmethod
-    def enabled(fn: Callable) -> Callable:
-        """Decorator to call or ignore a function based on the `enabled` flag.
-
-        Parameters
-        ----------
-        fn : Callable
-            Function to wrap with enable flag.
-
-        Returns
-        -------
-        function | None
-            Wrapped function or None if `_enabled` property is False.
-        """
+    def enabled(fn: Callable) -> Callable:  # noqa: N805
+        """Decorator to call or ignore a function based on the `enabled` flag."""
 
         @wraps(fn)
         def _wrapper(self: TokenAuth, *args, **kwargs) -> Callable | None:


### PR DESCRIPTION
During initial release QA, the `enabled` decorator in `TokenAuth` was turned into a staticmethod as a way to satisfy the linter, because it would complain about the argument not being named `self`.

This breaks the code in python 3.9, where static methods cannot be called from within the class. 
When running the login command on python 3.9:

```shell
Traceback (most recent call last):
  File "./conda/envs/aifs-dev-py39/bin/anemoi-training", line 8, in <module>
    sys.exit(main())
  File "./anemoi-training/src/anemoi/training/__main__.py", line 23, in main
    cli_main(__version__, __doc__, COMMANDS)
  File "./conda/envs/aifs-dev-py39/lib/python3.9/site-packages/anemoi/utils/cli.py", line 135, in cli_main
    cmd.run(args)
  File "./anemoi-training/src/anemoi/training/commands/mlflow.py", line 79, in run
    from anemoi.training.diagnostics.mlflow.auth import TokenAuth
  File "./anemoi-training/src/anemoi/training/diagnostics/mlflow/auth.py", line 28, in <module>
    class TokenAuth:
  File "./anemoi-training/src/anemoi/training/diagnostics/mlflow/auth.py", line 102, in TokenAuth
    def login(self, force_credentials: bool = False, **kwargs: dict) -> None:
TypeError: 'staticmethod' object is not callable
```

The trace is not very clear, but `login` is decorated with `enabled`, and the call to the latter is throwing the error.

The solution is to simply remove the staticmethod decorator, because `enabled` does not need to be a static method in the first place. 

Thanks to @JPXKQX for finding the bug.