### PR TITLE
Bind max steps and lr iterations

### DIFF
--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -46,10 +46,12 @@ rollout:
   # maximum rollout to use
   max: 1
 
-max_epochs: 200
+max_epochs: null
+max_steps: 150000
+
 lr:
   rate: 0.625e-4 #local_lr
-  iterations: 300000
+  iterations: ${training.max_steps}
   min: 3e-7 #Not scaled by #GPU
 
 # Changes in per-gpu batch_size should come with a rescaling of the local_lr

--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -47,7 +47,7 @@ rollout:
   max: 1
 
 max_epochs: null
-max_steps: 150000
+max_steps: 150000 # set to -1 to run for max_epochs
 
 lr:
   rate: 0.625e-4 #local_lr

--- a/src/anemoi/training/train/train.py
+++ b/src/anemoi/training/train/train.py
@@ -323,6 +323,7 @@ class AnemoiTrainer:
             num_nodes=self.config.hardware.num_nodes,
             precision=self.config.training.precision,
             max_epochs=self.config.training.max_epochs,
+            max_steps=self.config.training.max_steps,
             logger=self.loggers,
             log_every_n_steps=self.config.diagnostics.log.interval,
             # run a fixed no of batches per epoch (helpful when debugging)


### PR DESCRIPTION
Context & Current Setup:
 - User defines training.lr.iterations which effects how many steps the model learns for
 - However, this often does not align with the training.max_epochs value which is often larger
 - GPU hours potentially wasted as max_epochs =/= training.lr.iterations
 - Alternatively unexpected results from training length not aligning to iteration schedule behaviour

Changes Aim to tie training.lr.iterations to the training length
1. Change default method to control run length to be by training.max_steps instead of training.max_epochs
2. Changed default setting in config such that training.lr.iterations defaults to training.max_steps
3. User now defines training.max_steps in order to define length of training
4. User still has the option to 

