### PR TITLE
Add output mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Keep it human-readable, your future self will thank you!
 - Feature: Add configurable models [#50](https://github.com/ecmwf/anemoi-training/pulls/50)
 - Feature: Support training for datasets with missing time steps [#48](https://github.com/ecmwf/anemoi-training/pulls/48)
 - Long Rollout Plots
+- Rollout training for Limited Area Models. [#79](https://github.com/ecmwf/anemoi-training/pulls/79)
 
 ### Fixed
 
@@ -33,6 +34,7 @@ Keep it human-readable, your future self will thank you!
 - Bugfixes for CI (#56)
 - Fix `mlflow` subcommand on python 3.9 [#62](https://github.com/ecmwf/anemoi-training/pull/62)
 - Show correct subcommand in MLFlow - Addresses [#39](https://github.com/ecmwf/anemoi-training/issues/39) in [#61](https://github.com/ecmwf/anemoi-training/pull/61)
+- Updated PlotSample callback to show only output region. [#79](https://github.com/ecmwf/anemoi-training/pulls/79)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Keep it human-readable, your future self will thank you!
 
 - Fix `TypeError` raised when trying to JSON serialise `datetime.timedelta` object - [#43](https://github.com/ecmwf/anemoi-training/pull/43)
 - Bugfixes for CI (#56)
+- Fix `mlflow` subcommand on python 3.9 [#62](https://github.com/ecmwf/anemoi-training/pull/62)
 - Show correct subcommand in MLFlow - Addresses [#39](https://github.com/ecmwf/anemoi-training/issues/39) in [#61](https://github.com/ecmwf/anemoi-training/pull/61)
 
 ### Changed

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -689,15 +689,16 @@ class PlotSample(BasePlotCallback):
             ...,
             pl_module.data_indices.internal_data.output.full,
         ].cpu()
-        data = self.post_processors(input_tensor).numpy()
+        data = self.post_processors(input_tensor)
 
         output_tensor = self.post_processors(
             torch.cat(tuple(x[self.sample_idx : self.sample_idx + 1, ...].cpu() for x in outputs[1])),
             in_place=False,
-        ).numpy()
+        )
 
-        data = self.apply_output_mask(pl_module, data)
-        output_tensor = self.apply_output_mask(pl_module, output_tensor)
+        output_tensor = pl_module.output_mask.apply(output_tensor, dim=2, fill_value=np.nan).numpy()
+        data[1:, ...] = pl_module.output_mask.apply(data[1:, ...], dim=2, fill_value=np.nan)
+        data = data.numpy()
 
         for rollout_step in range(pl_module.rollout):
             fig = plot_predicted_multilevel_flat_sample(
@@ -786,14 +787,15 @@ class PlotAdditionalMetrics(BasePlotCallback):
             ...,
             pl_module.data_indices.internal_data.output.full,
         ].cpu()
-        data = self.post_processors(input_tensor).numpy()
+        data = self.post_processors(input_tensor)
         output_tensor = self.post_processors(
             torch.cat(tuple(x[self.sample_idx : self.sample_idx + 1, ...].cpu() for x in outputs[1])),
             in_place=False,
-        ).numpy()
+        )
 
-        data = self.apply_output_mask(pl_module, data)
-        output_tensor = self.apply_output_mask(pl_module, output_tensor)
+        output_tensor = pl_module.output_mask.apply(output_tensor, dim=2, fill_value=np.nan).numpy()
+        data[1:, ...] = pl_module.output_mask.apply(data[1:, ...], dim=2, fill_value=np.nan)
+        data = data.numpy()
 
         for rollout_step in range(pl_module.rollout):
             if self.config.diagnostics.plot.parameters_histogram is not None:

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -689,6 +689,10 @@ class PlotSample(BasePlotCallback):
             in_place=False,
         ).numpy()
 
+        if pl_module.output_mask is not None:
+            output_tensor[..., ~pl_module.output_mask, :] = np.nan
+            data[1:, :, ~pl_module.output_mask, :] = np.nan
+
         for rollout_step in range(pl_module.rollout):
             fig = plot_predicted_multilevel_flat_sample(
                 plot_parameters_dict,
@@ -781,6 +785,10 @@ class PlotAdditionalMetrics(BasePlotCallback):
             torch.cat(tuple(x[self.sample_idx : self.sample_idx + 1, ...].cpu() for x in outputs[1])),
             in_place=False,
         ).numpy()
+
+        if pl_module.output_mask is not None:
+            output_tensor[..., ~pl_module.output_mask, :] = np.nan
+            data[1:, :, ~pl_module.output_mask, :] = np.nan
 
         for rollout_step in range(pl_module.rollout):
             if self.config.diagnostics.plot.parameters_histogram is not None:

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -140,7 +140,7 @@ class BasePlotCallback(Callback, ABC):
             self._executor.shutdown(wait=True)
 
     def apply_output_mask(self, pl_module: pl.LightningModule, data: torch.Tensor) -> torch.Tensor:
-        if hasattr(pl_module, 'output_mask') and pl_module.output_mask is not None:
+        if hasattr(pl_module, "output_mask") and pl_module.output_mask is not None:
             # Fill with NaNs values where the mask is False
             data[:, :, ~pl_module.output_mask, :] = np.nan
 

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -139,6 +139,13 @@ class BasePlotCallback(Callback, ABC):
         if self._executor is not None:
             self._executor.shutdown(wait=True)
 
+    def apply_output_mask(self, pl_module: pl.LightningModule, data: torch.Tensor) -> torch.Tensor:
+        if hasattr(pl_module, 'output_mask') and pl_module.output_mask is not None:
+            # Fill with NaNs values where the mask is False
+            data[:, :, ~pl_module.output_mask, :] = np.nan
+
+        return data
+
     @abstractmethod
     @rank_zero_only
     def _plot(
@@ -689,9 +696,8 @@ class PlotSample(BasePlotCallback):
             in_place=False,
         ).numpy()
 
-        if pl_module.output_mask is not None:
-            output_tensor[..., ~pl_module.output_mask, :] = np.nan
-            data[1:, :, ~pl_module.output_mask, :] = np.nan
+        data = self.apply_output_mask(pl_module, data)
+        output_tensor = self.apply_output_mask(pl_module, output_tensor)
 
         for rollout_step in range(pl_module.rollout):
             fig = plot_predicted_multilevel_flat_sample(
@@ -786,9 +792,8 @@ class PlotAdditionalMetrics(BasePlotCallback):
             in_place=False,
         ).numpy()
 
-        if pl_module.output_mask is not None:
-            output_tensor[..., ~pl_module.output_mask, :] = np.nan
-            data[1:, :, ~pl_module.output_mask, :] = np.nan
+        data = self.apply_output_mask(pl_module, data)
+        output_tensor = self.apply_output_mask(pl_module, output_tensor)
 
         for rollout_step in range(pl_module.rollout):
             if self.config.diagnostics.plot.parameters_histogram is not None:

--- a/src/anemoi/training/diagnostics/mlflow/auth.py
+++ b/src/anemoi/training/diagnostics/mlflow/auth.py
@@ -75,20 +75,8 @@ class TokenAuth:
     def load_config() -> dict:
         return load_config(TokenAuth.config_file)
 
-    @staticmethod
-    def enabled(fn: Callable) -> Callable:
-        """Decorator to call or ignore a function based on the `enabled` flag.
-
-        Parameters
-        ----------
-        fn : Callable
-            Function to wrap with enable flag.
-
-        Returns
-        -------
-        function | None
-            Wrapped function or None if `_enabled` property is False.
-        """
+    def enabled(fn: Callable) -> Callable:  # noqa: N805
+        """Decorator to call or ignore a function based on the `enabled` flag."""
 
         @wraps(fn)
         def _wrapper(self: TokenAuth, *args, **kwargs) -> Callable | None:

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -31,6 +31,8 @@ from torch_geometric.data import HeteroData
 from anemoi.training.losses.mse import WeightedMSELoss
 from anemoi.training.losses.utils import grad_scaler
 from anemoi.training.utils.jsonify import map_config_to_primitives
+from anemoi.training.utils.masks import Boolean1DMask
+from anemoi.training.utils.masks import NoOutputMask
 
 LOGGER = logging.getLogger(__name__)
 
@@ -82,16 +84,11 @@ class GraphForecaster(pl.LightningModule):
         self.latlons_data = graph_data[config.graph.data].x
         self.loss_weights = graph_data[config.graph.data][config.model.node_loss_weight].squeeze()
 
-        # Set mask of data nodes to be output
-        if out_mask_name := config.model.get("output_mask", None) is not None:
-            assert out_mask_name in graph_data[config.graph.data], (
-                f"The attribute '{out_mask_name}' in output_mask does not exist in the graph. "
-                f"Options are: {', '.join(graph_data[config.graph.data].keys())}",
-            )
-            self.output_mask = graph_data[config.graph.data][out_mask_name].squeeze().bool()
-            self.loss_weights[~self.output_mask] = 0.0
+        if config.model.get("output_mask", None) is not None:
+            self.output_mask = Boolean1DMask(graph_data[config.graph.data][config.model.output_mask])
         else:
-            self.output_mask = torch.ones(self.latlons_data.shape[0], dtype=torch.bool, device=self.device)
+            self.output_mask = NoOutputMask()
+        self.loss_weights = self.output_mask.apply(self.loss_weights, dim=0, fill_value=0.0)
 
         self.logger_enabled = config.diagnostics.log.wandb.enabled or config.diagnostics.log.mlflow.enabled
 
@@ -213,11 +210,7 @@ class GraphForecaster(pl.LightningModule):
             self.data_indices.internal_model.output.prognostic,
         ]
 
-        # Fill in the boundary values (only for Limited Area Models)
-        if not self.output_mask.all():
-            _x = x[:, -1, :, :, self.data_indices.model.input.prognostic]
-            _x[..., ~self.output_mask, :] = batch[:, -1, :, ~self.output_mask][..., self.data_indices.data.output.full]
-            x[:, -1, :, :, self.data_indices.model.input.prognostic] = _x
+        x[:, -1] = self.output_mask.rollout_boundary(x[:, -1], batch[:, -1], self.data_indices)
 
         # get new "constants" needed for time-varying fields
         x[:, -1, :, :, self.data_indices.internal_model.input.forcing] = batch[

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -86,8 +86,8 @@ class GraphForecaster(pl.LightningModule):
         if out_mask_name := config.model.get("output_mask", None) is not None:
             assert (
                 out_mask_name in graph_data[config.graph.data],
-                f"The attribute \'{out_mask_name}\' in output_mask does not exist in the graph. "
-                f"Options are: {', '.join(graph_data[config.graph.data].keys())}"
+                f"The attribute '{out_mask_name}' in output_mask does not exist in the graph. "
+                f"Options are: {', '.join(graph_data[config.graph.data].keys())}",
             )
             self.output_mask = graph_data[config.graph.data][out_mask_name].squeeze().bool()
             self.loss_weights[~self.output_mask] = 0.0

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -84,8 +84,7 @@ class GraphForecaster(pl.LightningModule):
 
         # Set mask of data nodes to be output
         if out_mask_name := config.model.get("output_mask", None) is not None:
-            assert (
-                out_mask_name in graph_data[config.graph.data],
+            assert out_mask_name in graph_data[config.graph.data], (
                 f"The attribute '{out_mask_name}' in output_mask does not exist in the graph. "
                 f"Options are: {', '.join(graph_data[config.graph.data].keys())}",
             )

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -23,11 +23,11 @@ class BaseMask:
 
     @abstractmethod
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-        pass
+        raise NotImplementedError("Method `apply` must be implemented in subclass.")
 
     @abstractmethod
     def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-        pass
+        raise NotImplementedError("Method `rollout_boundary` must be implemented in subclass.")
 
 
 class Boolean1DMask(BaseMask):

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -20,13 +20,13 @@ if TYPE_CHECKING:
 class BaseMask:
     """Base class for masking model output."""
 
-    def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
         return x
 
-    def apply_inverse(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    def apply_inverse(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
         return x
 
-    def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
         return x
 
 

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -8,6 +8,7 @@
 #
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -20,14 +21,13 @@ if TYPE_CHECKING:
 class BaseMask:
     """Base class for masking model output."""
 
-    def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
-        return x
+    @abstractmethod
+    def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        pass
 
-    def apply_inverse(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
-        return x
-
-    def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
-        return x
+    @abstractmethod
+    def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        pass
 
 
 class Boolean1DMask(BaseMask):
@@ -50,10 +50,6 @@ class Boolean1DMask(BaseMask):
         if isinstance(fill_value, torch.Tensor):
             return x.masked_scatter(mask, fill_value)
         return x.masked_fill(mask, fill_value)
-
-    def apply_inverse(self, x: torch.Tensor, dim: int, fill_value: float | torch.Tensor = np.nan) -> torch.Tensor:
-        mask = self.broadcast_like(x, dim)
-        return Boolean1DMask._fill_masked_tensor(x, mask, fill_value)
 
     def apply(self, x: torch.Tensor, dim: int, fill_value: float | torch.Tensor = np.nan) -> torch.Tensor:
         """Apply the mask to the input tensor.
@@ -108,3 +104,9 @@ class Boolean1DMask(BaseMask):
 
 class NoOutputMask(BaseMask):
     """No output mask."""
+
+    def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
+        return x
+
+    def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:  # noqa: ARG002
+        return x

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -23,11 +23,13 @@ class BaseMask:
 
     @abstractmethod
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-        raise NotImplementedError("Method `apply` must be implemented in subclass.")
+        error_message = "Method `apply` must be implemented in subclass."
+        raise NotImplementedError(error_message)
 
     @abstractmethod
     def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-        raise NotImplementedError("Method `rollout_boundary` must be implemented in subclass.")
+        error_message = "Method `rollout_boundary` must be implemented in subclass."
+        raise NotImplementedError(error_message)
 
 
 class Boolean1DMask(BaseMask):

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -56,6 +56,22 @@ class Boolean1DMask(BaseMask):
         return Boolean1DMask._fill_masked_tensor(x, mask, fill_value)
 
     def apply(self, x: torch.Tensor, dim: int, fill_value: float | torch.Tensor = np.nan) -> torch.Tensor:
+        """Apply the mask to the input tensor.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            The input tensor to be masked.
+        dim : int
+            The dimension along which to apply the mask.
+        fill_value : float | torch.Tensor, optional
+            The value to fill in the masked positions, by default np.nan.
+
+        Returns
+        -------
+        torch.Tensor
+            The masked tensor with fill_value in the positions where the mask is False.
+        """
         mask = self.broadcast_like(x, dim)
         return Boolean1DMask._fill_masked_tensor(x, ~mask, fill_value)
 

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -1,0 +1,94 @@
+# (C) Copyright 2024 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+if TYPE_CHECKING:
+    from anemoi.models.data_indices.collection import IndexCollection
+
+
+class BaseMask:
+    """Base class for masking model output."""
+
+    def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        return x
+
+    def apply_inverse(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        return x
+
+    def rollout_boundary(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        return x
+
+
+class Boolean1DMask(BaseMask):
+    """1D Boolean mask."""
+
+    def __init__(self, values: torch.Tensor) -> None:
+        self.mask = values.bool().squeeze()
+
+    def broadcast_like(self, x: torch.Tensor, dim: int) -> torch.Tensor:
+        assert x.shape[dim] == len(
+            self.mask,
+        ), f"Dimension mismatch: dimension {dim} has size {x.shape[dim]}, but mask length is {len(self.mask)}."
+        target_shape = [1 for _ in range(x.ndim)]
+        target_shape[dim] = len(self.mask)
+        mask = self.mask.reshape(target_shape)
+        return mask.to(x.device)
+
+    @staticmethod
+    def _fill_masked_tensor(x: torch.Tensor, mask: torch.Tensor, fill_value: float | torch.Tensor) -> torch.Tensor:
+        if isinstance(fill_value, torch.Tensor):
+            return x.masked_scatter(mask, fill_value)
+        return x.masked_fill(mask, fill_value)
+
+    def apply_inverse(self, x: torch.Tensor, dim: int, fill_value: float | torch.Tensor = np.nan) -> torch.Tensor:
+        mask = self.broadcast_like(x, dim)
+        return Boolean1DMask._fill_masked_tensor(x, mask, fill_value)
+
+    def apply(self, x: torch.Tensor, dim: int, fill_value: float | torch.Tensor = np.nan) -> torch.Tensor:
+        mask = self.broadcast_like(x, dim)
+        return Boolean1DMask._fill_masked_tensor(x, ~mask, fill_value)
+
+    def rollout_boundary(
+        self,
+        pred_state: torch.Tensor,
+        true_state: torch.Tensor,
+        data_indices: IndexCollection,
+    ) -> torch.Tensor:
+        """Rollout the boundary forcing.
+
+        Parameters
+        ----------
+        pred_state : torch.Tensor
+            The predicted state tensor of shape (bs, ens, latlon, nvar)
+        true_state : torch.Tensor
+            The true state tensor of shape (bs, ens, latlon, nvar)
+        data_indices : IndexCollection
+            Collection of data indices.
+
+        Returns
+        -------
+        torch.Tensor
+            The updated predicted state tensor with boundary forcing applied.
+        """
+        pred_state[..., data_indices.model.input.prognostic] = self.apply(
+            pred_state[..., data_indices.model.input.prognostic],
+            dim=2,
+            fill_value=true_state[..., data_indices.data.output.prognostic],
+        )
+
+        return pred_state
+
+
+class NoOutputMask(BaseMask):
+    """No output mask."""


### PR DESCRIPTION
This PR adds an output_mask attribute to the GraphForecaster class. This enables rollout training for LAM models and simplifies the diagnostics plot to include only the limited area.

![Diagnostic plor](https://github.com/user-attachments/assets/6850eaf3-f924-4fa7-9028-80c42b6835ec)

For global models, the previous behaviour is retained where the output_mask is all 1s.
