### PR TITLE
Fix interactive multi-GPU training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Keep it human-readable, your future self will thank you!
 - Bugfixes for CI (#56)
 - Fix `mlflow` subcommand on python 3.9 [#62](https://github.com/ecmwf/anemoi-training/pull/62)
 - Show correct subcommand in MLFlow - Addresses [#39](https://github.com/ecmwf/anemoi-training/issues/39) in [#61](https://github.com/ecmwf/anemoi-training/pull/61)
+- Fix interactive multi-GPU training [#82](https://github.com/ecmwf/anemoi-training/pull/82)
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ urls.Documentation = "https://anemoi-training.readthedocs.io/"
 urls.Homepage = "https://github.com/ecmwf/anemoi-training/"
 urls.Issues = "https://github.com/ecmwf/anemoi-training/issues"
 urls.Repository = "https://github.com/ecmwf/anemoi-training/"
+# command for interactive DDP (not supposed to be used directly)
+# the dot is intentional, so it doesn't trigger autocomplete
+scripts.".anemoi-training-train" = "anemoi.training.commands.train:main"
+
 # Add subcommand in the `commands` directory
 scripts.anemoi-training = "anemoi.training.__main__:main"
 

--- a/src/anemoi/training/commands/train.py
+++ b/src/anemoi/training/commands/train.py
@@ -50,6 +50,7 @@ class Train(Command):
         """Merge the sys.argv with the known subcommands to pass to hydra.
 
         This is done for interactive DDP, which will spawn the rank > 0 processes from sys.argv[0]
+        and for hydra, which ingests sys.argv[1:]
 
         Parameters
         ----------
@@ -64,7 +65,7 @@ class Train(Command):
         argv = Path(sys.argv[0])
 
         # this will turn "/env/bin/anemoi-training train" into "/env/bin/.anemoi-training-train"
-        # the dot at the beginning is intentional to not trigger autocomplete
+        # the dot at the beginning is intentional to not interfere with autocomplete
         modified_sysargv = argv.with_name(f".{argv.name}-{args.command}")
 
         if hasattr(args, "subcommand"):

--- a/src/anemoi/training/commands/train.py
+++ b/src/anemoi/training/commands/train.py
@@ -9,7 +9,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from anemoi.training.commands import Command
@@ -30,7 +32,8 @@ class Train(Command):
         return parser
 
     def run(self, args: argparse.Namespace, unknown_args: list[str] | None = None) -> None:
-
+        # This will be picked up by the logger
+        os.environ["ANEMOI_TRAINING_CMD"] = f"{sys.argv[0]} {args.command}"
         # Merge the known subcommands with a non-whitespace character for hydra
         new_sysargv = self._merge_sysargv(args)
 
@@ -40,14 +43,13 @@ class Train(Command):
         else:
             sys.argv = [new_sysargv]
 
-        # Import and run the training command
         LOGGER.info("Running anemoi training command with overrides: %s", sys.argv[1:])
-        from anemoi.training.train.train import main as anemoi_train
-
-        anemoi_train()
+        main()
 
     def _merge_sysargv(self, args: argparse.Namespace) -> str:
         """Merge the sys.argv with the known subcommands to pass to hydra.
+
+        This is done for interactive DDP, which will spawn the rank > 0 processes from sys.argv[0]
 
         Parameters
         ----------
@@ -59,10 +61,26 @@ class Train(Command):
         str
             Modified sys.argv as string
         """
-        modified_sysargv = f"{sys.argv[0]} {args.command}"
+        argv = Path(sys.argv[0])
+
+        # this will turn "/env/bin/anemoi-training train" into "/env/bin/.anemoi-training-train"
+        # the dot at the beginning is intentional to not trigger autocomplete
+        modified_sysargv = argv.with_name(f".{argv.name}-{args.command}")
+
         if hasattr(args, "subcommand"):
-            modified_sysargv += f" {args.subcommand}"
-        return modified_sysargv
+            modified_sysargv += f"-{args.subcommand}"
+        return str(modified_sysargv)
+
+
+def main() -> None:
+    # Use the environment variable to check if main is being called from the subcommand, not from the ddp entrypoint
+    if not os.environ.get("ANEMOI_TRAINING_CMD"):
+        error = "This entrypoint should not be called directly. Use `anemoi-training train` instead."
+        raise RuntimeError(error)
+
+    from anemoi.training.train.train import main as anemoi_train
+
+    anemoi_train()
 
 
 command = Train

--- a/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -66,7 +66,9 @@ def get_mlflow_run_params(config: OmegaConf, tracking_uri: str) -> tuple[str | N
     run_id = None
     tags = {"projectName": config.diagnostics.log.mlflow.project_name}
     # create a tag with the command used to run the script
-    tags["command"] = sys.argv[0].split("/")[-1]  # get the python script name
+    command = os.environ.get("ANEMOI_TRAINING_CMD", sys.argv[0])
+    tags["command"] = command.split("/")[-1]  # get the python script name
+    tags["mlflow.source.name"] = command
     if len(sys.argv) > 1:
         # add the arguments to the command tag
         tags["command"] = tags["command"] + " " + " ".join(sys.argv[1:])


### PR DESCRIPTION
This is a proposed fix for interactive multi-GPU training, which is currently broken.

"interactive" in this context means: you call `anemoi-training train` directly in a shell.

### Background

Hydra expects full control over `sys.argv` , with `argv[0]` being the executable, and `argv[1:]` the hydra options.
This is incompatible with our subcommands, where `argv[0]` is `anemoi-training` and `argv[1]` is something like `train`. Hydra will try to ingest `train` as an option, and crash.

To get around this, we overwrite the argv so that `argv[0]` contains the executable and subcommand: `anemoi-training train`.

This makes hydra happy, and it works fine with 1 GPU.

### What works

For most training runs, we run training via Slurm. For this, we don't call the training command directly but we do `srun anemoi-training train` , typically from an sbatch script (but can also be done directly).

The above works fine, because under the hood Slurm will take the argument of srun and execute it once for each GPU. PTL then takes care of the synchronisation between the processes. This can be seen here:

![image](https://github.com/user-attachments/assets/3e67caed-953c-4883-bebc-1d0c1871df26)

One `srun` call results in 2 `anemoi-training train` processes being spawned, one for each GPU (`num_gpus_per_node=2`).

So far so good! 

### What doesn't work

When we run `anemoi-training train` interactively, that is without Slurm, things break. 

This is because without Slurm, PTL will take over responsibility of spawning the subprocesses for each GPU. And as can be seen [here](https://github.com/Lightning-AI/pytorch-lightning/blob/8ad3e29816a63d8ce5c00ac104b14729a4176f4f/src/lightning/fabric/strategies/launchers/subprocess_script.py#L173), it does this by doing a `subprocess.Popen` on the value in `sys.argv[0]`. 

At first glance this looks like it should work, after all `argv[0]` contains `anemoi-training train`. 
But that binary does not exist. So when it tries to open `anemoi-training train` it crashes:

```
/envs/anemoi/bin/python3.10: can't open file '/envs/anemoi/bin/anemoi-training train': [Errno 2] No such file or directory
```

So there is a conflict with the argv. We hack `argv[0]` to make hydra happy, but at the same time it needs to contain a valid binary so that PTL can spawn the DDP processes.

### A solution

One simple solution is to put a value in `argv[0]` that points to a valid binary.

In this PR, I introduce a new "hidden" entry point `.anemoi-training-train` that points to the hydra main function.

Here you can see it working, the top process for GPU 1 is `anemoi-training train`, while the subprocess for GPU 2 is `.anemoi-training-train`:
![image](https://github.com/user-attachments/assets/800a7e39-c188-4d5c-9e34-61cd0d0d2ff6)


I put the dot at the beginning so that it does not get suggested by autocomplete, because we don't really want users to use this entry point directly. That is also why I added an environment variable to check if the entry point is being called by the subcommand, and not directly.

I then also use that environment variable to log the original command to mlflow. I did not want to touch the top Anemoi trainer interface, so I opted for an env var instead of passing an argument all the way through to the logger.

This is not the cleanest solution. Having this "hidden" entry point is not ideal, so I'm open to suggestions. But I'm in favour of accepting a less-than-ideal solution if it solves the problem in the short run, and then improve it.

This also means that if we have any other subcommands invoking the trainer, we need to have a corresponding "hidden" entry point (e.g.: the profiler).

closes #80 