### PR TITLE
Refactor rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Keep it human-readable, your future self will thank you!
 ### Added
 ### Fixed
 - Refactored callbacks. [#60](https://github.com/ecmwf/anemoi-training/pulls/60)
+- Refactored rollout [#87](https://github.com/ecmwf/anemoi-training/pulls/87)
+    - Enable longer validation rollout than training
 ### Changed
 
 ## [0.2.0 - Feature release](https://github.com/ecmwf/anemoi-training/compare/0.1.0...0.2.0) - 2024-10-16

--- a/docs/modules/diagnostics.rst
+++ b/docs/modules/diagnostics.rst
@@ -21,18 +21,17 @@ functionality to use both Weights & Biases and Tensorboard.
 
 The callbacks can also be used to evaluate forecasts over longer
 rollouts beyond the forecast time that the model is trained on. The
-number of rollout steps (or forecast iteration steps) is set using
-``config.eval.rollout = *num_of_rollout_steps*``.
+number of rollout steps for verification (or forecast iteration steps)
+is set using ``config.dataloader.validation_rollout =
+*num_of_rollout_steps*``.
 
 Note the user has the option to evaluate the callbacks asynchronously
 (using the following config option
 ``config.diagnostics.plot.asynchronous``, which means that the model
 training doesn't stop whilst the callbacks are being evaluated).
-However, note that callbacks can still be slow, and therefore the
-plotting callbacks can be switched off by setting
-``config.diagnostics.plot.enabled`` to ``False`` or all the callbacks
-can be completely switched off by setting
-``config.diagnostics.eval.enabled`` to ``False``.
+Callbacks are configured in the config file under the
+``config.diagnostics.callbacks`` key, and plotting callbacks under the
+``config.diagnostics.plot`` key.
 
 Below is the documentation for the default callbacks provided, but it is
 also possible for users to add callbacks using the same structure:

--- a/src/anemoi/training/config/config.yaml
+++ b/src/anemoi/training/config/config.yaml
@@ -1,7 +1,7 @@
 defaults:
 - data: zarr
 - dataloader: native_grid
-- diagnostics: eval_rollout
+- diagnostics: evaluation
 - hardware: example
 - graph: multi_scale
 - model: gnn

--- a/src/anemoi/training/config/dataloader/native_grid.yaml
+++ b/src/anemoi/training/config/dataloader/native_grid.yaml
@@ -44,6 +44,8 @@ training:
   frequency: ${data.frequency}
   drop:  []
 
+validation_rollout: 1 # number of rollouts to use for validation, must be equal or greater than rollout expected by callbacks
+
 validation:
   dataset: ${dataloader.dataset}
   start: 2021

--- a/src/anemoi/training/config/diagnostics/callbacks/pretraining.yaml
+++ b/src/anemoi/training/config/diagnostics/callbacks/pretraining.yaml
@@ -1,4 +1,1 @@
 # Add callbacks here
-# - _target_: anemoi.training.diagnostics.callbacks.evaluation.RolloutEval
-#   rollout: ${diagnostics.eval.rollout}
-#   frequency: ${diagnostics.eval.frequency}

--- a/src/anemoi/training/config/diagnostics/callbacks/rollout_eval.yaml
+++ b/src/anemoi/training/config/diagnostics/callbacks/rollout_eval.yaml
@@ -1,4 +1,4 @@
 # Add callbacks here
 - _target_: anemoi.training.diagnostics.callbacks.evaluation.RolloutEval
-  rollout: ${diagnostics.eval.rollout}
-  frequency: ${diagnostics.eval.frequency}
+  rollout: ${dataloader.validation_rollout}
+  frequency: 20

--- a/src/anemoi/training/config/diagnostics/evaluation.yaml
+++ b/src/anemoi/training/config/diagnostics/evaluation.yaml
@@ -3,11 +3,6 @@ defaults:
   - plot: detailed
   - callbacks: pretraining
 
-eval:
-  enabled: False
-  # use this to evaluate the model over longer rollouts, every so many validation batches
-  rollout: 12
-  frequency: 20
 
 debug:
   # this will detect and trace back NaNs / Infs etc. but will slow down training

--- a/src/anemoi/training/config/diagnostics/plot/detailed.yaml
+++ b/src/anemoi/training/config/diagnostics/plot/detailed.yaml
@@ -59,7 +59,8 @@ callbacks:
     - 2t
     - 10u
     - 10v
-  # - _target_:  anemoi.training.diagnostics.callbacks.plot.LongRolloutPlots
-  #   rollout: [60]
-  #   batch_frequency: 10
-  #   epoch_frequency: 20
+  - _target_:  anemoi.training.diagnostics.callbacks.plot.LongRolloutPlots
+    rollout:
+      - ${dataloader.validation_rollout}
+    batch_frequency: 10
+    epoch_frequency: 20

--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -123,10 +123,8 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
     @cached_property
     def ds_valid(self) -> NativeGridDataset:
         r = self.rollout
-        if self.config.diagnostics.eval.enabled:
-            r = max(r, self.config.diagnostics.eval.rollout)
-        if self.config.diagnostics.plot.get("longrollout") and self.config.diagnostics.plot.longrollout.enabled:
-            r = max(r, max(self.config.diagnostics.plot.longrollout.rollout))
+        r = max(r, self.config.dataloader.get("validation_rollout", 1))
+
         assert self.config.dataloader.training.end < self.config.dataloader.validation.start, (
             f"Training end date {self.config.dataloader.training.end} is not before"
             f"validation start date {self.config.dataloader.validation.start}"

--- a/src/anemoi/training/diagnostics/callbacks/evaluation.py
+++ b/src/anemoi/training/diagnostics/callbacks/evaluation.py
@@ -32,6 +32,10 @@ class RolloutEval(Callback):
         ----------
         config : dict
             Dictionary with configuration settings
+        rollout : int
+            Rollout length for evaluation
+        frequency : int
+            Frequency of evaluation, per batch
 
         """
         super().__init__()
@@ -52,6 +56,11 @@ class RolloutEval(Callback):
     ) -> None:
         loss = torch.zeros(1, dtype=batch.dtype, device=pl_module.device, requires_grad=False)
         metrics = {}
+
+        assert batch.shape[1] >= self.rollout + pl_module.multi_step, (
+            "Batch length not sufficient for requested validation rollout length! "
+            f"Set `dataloader.validation_rollout` to at least {self.rollout + pl_module.multi_step}"
+        )
 
         with torch.no_grad():
             for loss_next, metrics_next, _ in pl_module.rollout_step(batch, rollout=self.rollout, validation_mode=True):

--- a/src/anemoi/training/diagnostics/callbacks/evaluation.py
+++ b/src/anemoi/training/diagnostics/callbacks/evaluation.py
@@ -53,33 +53,9 @@ class RolloutEval(Callback):
         loss = torch.zeros(1, dtype=batch.dtype, device=pl_module.device, requires_grad=False)
         metrics = {}
 
-        # start rollout
-        batch = pl_module.model.pre_processors(batch, in_place=False)
-        x = batch[
-            :,
-            0 : pl_module.multi_step,
-            ...,
-            pl_module.data_indices.internal_data.input.full,
-        ]  # (bs, multi_step, latlon, nvar)
-        assert (
-            batch.shape[1] >= self.rollout + pl_module.multi_step
-        ), "Batch length not sufficient for requested rollout length!"
-
         with torch.no_grad():
-            for rollout_step in range(self.rollout):
-                y_pred = pl_module(x)  # prediction at rollout step rollout_step, shape = (bs, latlon, nvar)
-                y = batch[
-                    :,
-                    pl_module.multi_step + rollout_step,
-                    ...,
-                    pl_module.data_indices.internal_data.output.full,
-                ]  # target, shape = (bs, latlon, nvar)
-                # y includes the auxiliary variables, so we must leave those out when computing the loss
-                loss += pl_module.loss(y_pred, y)
-
-                x = pl_module.advance_input(x, y_pred, batch, rollout_step)
-
-                metrics_next, _ = pl_module.calculate_val_metrics(y_pred, y, rollout_step)
+            for loss_next, metrics_next, _ in pl_module.rollout_step(batch, rollout=self.rollout, validation_mode=True):
+                loss += loss_next
                 metrics.update(metrics_next)
 
             # scale loss
@@ -88,7 +64,7 @@ class RolloutEval(Callback):
 
     def _log(self, pl_module: pl.LightningModule, loss: torch.Tensor, metrics: dict, bs: int) -> None:
         pl_module.log(
-            f"val_r{self.rollout}_wmse",
+            f"val_r{self.rollout}_{getattr(pl_module.loss, 'name', pl_module.loss.__class__.__name__.lower())}",
             loss,
             on_epoch=True,
             on_step=True,

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -11,7 +11,9 @@ import logging
 import math
 import os
 from collections import defaultdict
+from collections.abc import Generator
 from collections.abc import Mapping
+from typing import Optional
 
 import numpy as np
 import pytorch_lightning as pl
@@ -212,17 +214,36 @@ class GraphForecaster(pl.LightningModule):
         ]
         return x
 
-    def _step(
+    def rollout_step(
         self,
         batch: torch.Tensor,
-        batch_idx: int,
+        rollout: Optional[int] = None,  # noqa: FA100
         validation_mode: bool = False,
-    ) -> tuple[torch.Tensor, Mapping[str, torch.Tensor]]:
-        del batch_idx
-        loss = torch.zeros(1, dtype=batch.dtype, device=self.device, requires_grad=False)
+    ) -> Generator[tuple[torch.Tensor, dict, list], None, None]:
+        """
+        Rollout step for the forecaster.
+
+        Parameters
+        ----------
+        batch : torch.Tensor
+            Batch to use for rollout
+        rollout : int | None, optional
+            Number of times to rollout for, by default None
+        validation_mode : bool, optional
+            Whether in validation mode, by default False
+
+        Yields
+        ------
+        Generator[tuple[torch.Tensor, dict, list], None, None]
+            Loss value, metrics, and predictions (per step)
+
+        Returns
+        -------
+        None
+            None
+        """
         # for validation not normalized in-place because remappers cannot be applied in-place
         batch = self.model.pre_processors(batch, in_place=not validation_mode)
-        metrics = {}
 
         # start rollout of preprocessed batch
         x = batch[
@@ -231,18 +252,24 @@ class GraphForecaster(pl.LightningModule):
             ...,
             self.data_indices.internal_data.input.full,
         ]  # (bs, multi_step, latlon, nvar)
+        msg = (
+            "Batch length not sufficient for requested multi_step length!"
+            f", {batch.shape[1]} !>= {rollout + self.multi_step}"
+        )
+        assert batch.shape[1] >= rollout + self.multi_step, msg
 
-        y_preds = []
-        for rollout_step in range(self.rollout):
+        for rollout_step in range(rollout or self.rollout):
             # prediction at rollout step rollout_step, shape = (bs, latlon, nvar)
             y_pred = self(x)
 
             y = batch[:, self.multi_step + rollout_step, ..., self.data_indices.internal_data.output.full]
             # y includes the auxiliary variables, so we must leave those out when computing the loss
-            loss += checkpoint(self.loss, y_pred, y, use_reentrant=False)
+            loss = checkpoint(self.loss, y_pred, y, use_reentrant=False)
 
             x = self.advance_input(x, y_pred, batch, rollout_step)
 
+            metrics_next = {}
+            y_preds_next = []
             if validation_mode:
                 metrics_next, y_preds_next = self.calculate_val_metrics(
                     y_pred,
@@ -250,10 +277,28 @@ class GraphForecaster(pl.LightningModule):
                     rollout_step,
                     enable_plot=self.enable_plot,
                 )
-                metrics.update(metrics_next)
-                y_preds.extend(y_preds_next)
+            yield loss, metrics_next, y_preds_next
 
-        # scale loss
+    def _step(
+        self,
+        batch: torch.Tensor,
+        batch_idx: int,
+        validation_mode: bool = False,
+    ) -> tuple[torch.Tensor, Mapping[str, torch.Tensor]]:
+        del batch_idx
+        loss = torch.zeros(1, dtype=batch.dtype, device=self.device, requires_grad=False)
+        metrics = {}
+        y_preds = []
+
+        for loss_next, metrics_next, y_preds_next in self.rollout_step(
+            batch,
+            rollout=self.rollout,
+            validation_mode=validation_mode,
+        ):
+            loss += loss_next
+            metrics.update(metrics_next)
+            y_preds.extend(y_preds_next)
+
         loss *= 1.0 / self.rollout
         return loss, metrics, y_preds
 


### PR DESCRIPTION
# Rollout Refactor
## Problem

`RolloutEval` and `GraphForecaster` rollout code had diverged from an inital copy.
This PR refactors both to combine the rollout logic.

Closes #84 

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview anemoi-training end -->