### PR TITLE
Lock python version to <3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased](https://github.com/ecmwf/anemoi-training/compare/0.2.1...HEAD)
 
+### Changed
+- Lock python version <3.13 [#107](https://github.com/ecmwf/anemoi-training/pull/107)
+
 ## [0.2.1 - Bugfix: resuming mlflow runs](https://github.com/ecmwf/anemoi-training/compare/0.2.0...0.2.1) - 2024-10-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
   { name = "European Centre for Medium-Range Weather Forecasts (ECMWF)", email = "software.support@ecmwf.int" },
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13" # Unable to use 3.13 until pyshtools updates
 
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Issue
`pyshtools` cannot be installed from pypi or conda for `3.13`
NOTE: Can be installed from source

## Resolution
Pin version to `<3.13`
- Temporary fix while pyshtools cannot be installed on 3.13


See https://github.com/SHTOOLS/SHTOOLS/issues/494 for more information