### PR TITLE
Feature: Add label checking workflow

### DIFF
--- a/.github/workflows/label-pr-check.yml
+++ b/.github/workflows/label-pr-check.yml
@@ -1,0 +1,24 @@
+---
+    name: Label Checker
+    on:
+      pull_request:
+        types:
+          - opened
+          - synchronize
+          - reopened
+          - labeled
+          - unlabeled
+        branches:
+          - develop
+
+    jobs:
+
+      check_labels:
+        name: Check labels
+        runs-on: ubuntu-latest
+        steps:
+          - uses: docker://agilepathway/pull-request-label-checker:latest
+            with:
+              any_of: ATS approved, No approval needed
+              none_of: invalid,wontfix,duplicate,question
+              repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-pr-check.yml
+++ b/.github/workflows/label-pr-check.yml
@@ -19,6 +19,6 @@
         steps:
           - uses: docker://agilepathway/pull-request-label-checker:latest
             with:
-              any_of: ATS approved, No approval needed
+              any_of: ATS approved,No approval needed
               none_of: invalid,wontfix,duplicate,question
               repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-pr-check.yml
+++ b/.github/workflows/label-pr-check.yml
@@ -10,10 +10,10 @@
           - unlabeled
         branches:
           - develop
-
     jobs:
 
       check_labels:
+        if: github.event.pull_request.draft == false
         name: Check labels
         runs-on: ubuntu-latest
         steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Keep it human-readable, your future self will thank you!
 
 ### Added
 - Included more loss functions and allowed configuration [#70](https://github.com/ecmwf/anemoi-training/pull/70)
-- Added label checking workflow. Ensure's ATS approval on merge to develop.
+- Added label checking workflow. Ensure's ATS approval on merge to develop. [#112](https://github.com/ecmwf/anemoi-training/pull/112)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Keep it human-readable, your future self will thank you!
 
 ### Added
 - Included more loss functions and allowed configuration [#70](https://github.com/ecmwf/anemoi-training/pull/70)
+- Added label checking workflow. Ensure's ATS approval on merge to develop.
 
 ### Changed
 


### PR DESCRIPTION
Ensures ATS Approval before merge to develop

## Issue
It is unclear at the moment when PR's can be merged, particularly with ATS.

## Resolution
This adds a workflow step to check if the `ATS Approved`  or the `No approval needed` label is added to the PR. 
If not it will fail, and prevent merges.