### PR TITLE
fix: metric ranges in the validation space not the normalized space

### DIFF
--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -98,7 +98,7 @@ class GraphForecaster(pl.LightningModule):
 
         variable_scaling = self.get_feature_weights(config, data_indices)
 
-        self.val_metric_ranges, _ = self.get_val_metric_ranges(config, data_indices)
+        _, self.val_metric_ranges = self.get_val_metric_ranges(config, data_indices)
 
         # Kwargs to pass to the loss function
         loss_kwargs = {"node_weights": self.node_weights}


### PR DESCRIPTION
The wrong output was taken from the `get_val_metric_range` function in the `GraphForecaster`, so that `self.val_metric_ranges` lived in the normalized space. Applying these to the postprocessed fields leads to errors if the remappers are applied.

This PR fixes this.