### PR TITLE
fix: enable learningrate monitor automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Keep it human-readable, your future self will thank you!
 ### Fixed
 - Refactored callbacks. [#60](https://github.com/ecmwf/anemoi-training/pulls/60)
     - Updated docs [#115](https://github.com/ecmwf/anemoi-training/pull/115)
+    - Fix enabling LearningRateMonitor
 - Refactored rollout [#87](https://github.com/ecmwf/anemoi-training/pulls/87)
     - Enable longer validation rollout than training
 ### Added

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -49,7 +49,7 @@ CONFIG_ENABLED_CALLBACKS: list[tuple[list[str] | str | Callable[[DictConfig], bo
     ("training.swa.enabled", StochasticWeightAveraging),
     (
         lambda config: nestedget(config, "diagnostics.log.wandb.enabled", False)
-        or nestedget(config, "diagnostics.log.mlfow.enabled", False),
+        or nestedget(config, "diagnostics.log.mlflow.enabled", False),
         LearningRateMonitor,
     ),
 ]

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -30,8 +30,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def nestedget(conf: DictConfig, key, default):
-    """
-    Get a nested key from a DictConfig object
+    """Get a nested key from a DictConfig object
 
     E.g.
     >>> nestedget(config, "diagnostics.log.wandb.enabled", False)
@@ -49,8 +48,8 @@ def nestedget(conf: DictConfig, key, default):
 CONFIG_ENABLED_CALLBACKS: list[tuple[list[str] | str | Callable[[DictConfig], bool], type[Callback]]] = [
     ("training.swa.enabled", StochasticWeightAveraging),
     (
-        lambda config: nestedget(config, "diagnostics.log.wandb.enabled", False)
-        or nestedget(config, "diagnostics.log.mflow.enabled", False),
+        lambda config: nestedget(config, "diagnostics.log.wandb.enabled", True)
+        or nestedget(config, "diagnostics.log.mflow.enabled", True),
         LearningRateMonitor,
     ),
 ]

--- a/src/anemoi/training/diagnostics/callbacks/__init__.py
+++ b/src/anemoi/training/diagnostics/callbacks/__init__.py
@@ -48,8 +48,8 @@ def nestedget(conf: DictConfig, key, default):
 CONFIG_ENABLED_CALLBACKS: list[tuple[list[str] | str | Callable[[DictConfig], bool], type[Callback]]] = [
     ("training.swa.enabled", StochasticWeightAveraging),
     (
-        lambda config: nestedget(config, "diagnostics.log.wandb.enabled", True)
-        or nestedget(config, "diagnostics.log.mflow.enabled", True),
+        lambda config: nestedget(config, "diagnostics.log.wandb.enabled", False)
+        or nestedget(config, "diagnostics.log.mlfow.enabled", False),
         LearningRateMonitor,
     ),
 ]


### PR DESCRIPTION
LearningRateMonitor should be enabled automatically if tracking by mlflow or wandb is enabled. Right now there is a typo (mflow != mlflow) which means the learning rate is not tracked and therefore examination on mlflow is not possible. 

Possible reviewers: @HCookie 