### PR TITLE
Graph config for stretched grid graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Keep it human-readable, your future self will thank you!
 - Sub-hour datasets [#63](https://github.com/ecmwf/anemoi-training/pull/63)
 - Add synchronisation workflow [#92](https://github.com/ecmwf/anemoi-training/pull/92)
 - Feat: Anemoi Profiler compatible with mlflow and using Pytorch (Kineto) Profiler for memory report [38](https://github.com/ecmwf/anemoi-training/pull/38/)
-
+- New stretched grid config added, stretched_grid.yaml [#133](https://github.com/ecmwf/anemoi-training/pull/133)
 
 ### Changed
 - Renamed frequency keys in callbacks configuration. [#118](https://github.com/ecmwf/anemoi-training/pull/118)

--- a/src/anemoi/training/config/graph/stretched_grid.yaml
+++ b/src/anemoi/training/config/graph/stretched_grid.yaml
@@ -56,7 +56,7 @@ edges:
 attributes:
   edges:
     edge_length:
-      _target_: anemoi.graphs.edges.attributes.EdgeLenght
+      _target_: anemoi.graphs.edges.attributes.EdgeLength
       norm: unit-max
     edge_dirs:
       _target_: anemoi.graphs.edges.attributes.EdgeDirection

--- a/src/anemoi/training/config/graph/stretched_grid.yaml
+++ b/src/anemoi/training/config/graph/stretched_grid.yaml
@@ -10,6 +10,7 @@ nodes:
   data:
     node_builder:
       _target_: anemoi.graphs.nodes.ZarrDatasetNodes
+      dataset: ${dataloader.dataset}
     attributes:
       area_weight:
         _target_: anemoi.graphs.nodes.attributes.AreaWeights

--- a/src/anemoi/training/config/graph/stretched_grid.yaml
+++ b/src/anemoi/training/config/graph/stretched_grid.yaml
@@ -1,6 +1,6 @@
-# Stretched grid graph config intended to be used with a cutout dataset. 
-# The stretched mesh resolution used here is intended for o96 global resolution with 10km 
-# limited area resolution.  
+# Stretched grid graph config intended to be used with a cutout dataset.
+# The stretched mesh resolution used here is intended for o96 global resolution with 10km
+# limited area resolution.
 overwrite: False
 
 data: "data"
@@ -29,12 +29,12 @@ nodes:
       area_weights:
         _target_: anemoi.graphs.nodes.attributes.AreaWeights
         norm: unit-max
-    
+
 edges:
 # Encoder
 - source_name: ${graph.data}
   target_name: ${graph.hidden}
-  edge_builder: 
+  edge_builder:
     _target_: anemoi.graphs.edges.KNNEdges
     num_nearest_neighbours: 12
   attributes: ${graph.attributes.edges}

--- a/src/anemoi/training/config/graph/stretched_grid.yaml
+++ b/src/anemoi/training/config/graph/stretched_grid.yaml
@@ -1,0 +1,62 @@
+# Stretched grid graph config intended to be used with a cutout dataset. 
+# The stretched mesh resolution used here is intended for o96 global resolution with 10km 
+# limited area resolution.  
+overwrite: False
+
+data: "data"
+hidden: "hidden"
+
+nodes:
+  data:
+    node_builder:
+      _target_: anemoi.graphs.nodes.ZarrDatasetNodes
+    attributes:
+      area_weight:
+        _target_: anemoi.graphs.nodes.attributes.AreaWeights
+        norm: unit-max
+      cutout:
+        _target_: anemoi.graphs.nodes.attributes.CutOutMask
+  hidden:
+    node_builder:
+      _target_: anemoi.graphs.nodes.StretchedTriNodes
+      lam_resolution: 8
+      global_resolution: 5
+      reference_node_name: ${graph.data}
+      mask_attr_name: cutout
+      margin_radius_km: 11
+    attributes:
+      area_weights:
+        _target_: anemoi.graphs.nodes.attributes.AreaWeights
+        norm: unit-max
+    
+edges:
+# Encoder
+- source_name: ${graph.data}
+  target_name: ${graph.hidden}
+  edge_builder: 
+    _target_: anemoi.graphs.edges.KNNEdges
+    num_nearest_neighbours: 12
+  attributes: ${graph.attributes.edges}
+# Processor
+- source_name: ${graph.hidden}
+  target_name: ${graph.hidden}
+  edge_builder:
+    _target_: anemoi.graphs.edges.MultiScaleEdges
+    x_hops: 1
+  attributes: ${graph.attributes.edges}
+# Decoder
+- source_name: ${graph.hidden}
+  target_name: ${graph.data}
+  edge_builder:
+    _target_: anemoi.graphs.edges.KNNEdges
+    num_nearest_neighbours: 3
+  attributes: ${graph.attributes.edges}
+
+attributes:
+  edges:
+    edge_length:
+      _target_: anemoi.graphs.edges.attributes.EdgeLenght
+      norm: unit-max
+    edge_dirs:
+      _target_: anemoi.graphs.edges.attributes.EdgeDirection
+      norm: unit-std


### PR DESCRIPTION
**Description**
Adds a config file stretched_grid.yaml intended to be the default when training stretched grid models. 
- Intended to be used with a cutout dataset, and uses the StretchedTriNodes processor mesh with increased resolution over the limited area.
- Processor resolution 5 over the global and 8 over the limited area.
- 12 connections per processor node in the encoder and 3 conndections per input grid node in the decoder.
- Intended to be used with o96 global resolution and 10km limited area resolution for the input grid

Based on the setup used in https://arxiv.org/abs/2409.02891, but with lower resolution. Can be used with e.g. n320 + 2.5km by changing processor resolution to 7+10.

Sample graph using o96 and meps resampled to 10km is attached.

[stretched_grid.zip](https://github.com/user-attachments/files/17700622/stretched_grid.zip)
