### PR TITLE
Feature: Option to set / change area weighting outside of graph-creation

### DIFF
--- a/src/anemoi/training/data/scaling.py
+++ b/src/anemoi/training/data/scaling.py
@@ -14,6 +14,11 @@ from abc import abstractmethod
 
 import numpy as np
 
+import torch
+from torch_geometric.data import HeteroData
+from scipy.spatial import SphericalVoronoi
+from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -77,3 +82,53 @@ class NoPressureLevelScaler(BasePressureLevelScaler):
         del plev  # unused
         # no scaling, always return 1.0
         return 1.0
+
+class BaseAreaWeights:
+    """Method for overwriting the area-weights stored in the graph object."""
+
+    def __init__(self, target_nodes: str):
+        """Initialize area weights with target nodes.
+
+        Parameters
+        ----------
+        target_nodes : str
+            Name of the set of nodes to be rescaled (defined when creating the graph).
+        """
+        self.target = target_nodes
+
+    def area_weights(self, graph_data) -> torch.Tensor:
+        return torch.from_numpy(self.global_area_weights(graph_data))
+
+    def global_area_weights(self, graph_data: HeteroData) -> np.ndarray:
+        lats, lons = graph_data[self.target].x[:,0], graph_data[self.target].x[:,1]
+        points = latlon_rad_to_cartesian((np.asarray(lats), np.asarray(lons)))
+        sv = SphericalVoronoi(points, radius=1.0, center=[0.0, 0.0, 0.0])
+        area_weights = sv.calculate_areas()
+
+        return area_weights / np.max(area_weights)
+
+class StretchedGridCutoutAreaWeights(BaseAreaWeights):
+    """Rescale area weight of nodes inside the cutout area by setting their sum to a fraction of the sum of global nodes area weight."""
+
+    def __init__(self, target_nodes: str, cutout_weight_frac_of_global: float):
+        """Initialize area weights with target nodes and scaling factor for the cutout nodes area weight.
+        
+        Parameters
+        ----------
+        target_nodes : str
+            Name of the set of nodes to be rescaled (defined when creating the graph).
+        cutout_weight_frac_of_global: float
+            Scaling factor for the cutout nodes area weight - sum of cutout nodes area weight set to a fraction of the sum of global nodes area weight.     
+        """
+        super().__init__(target_nodes=target_nodes)
+        self.fraction = cutout_weight_frac_of_global
+
+    def area_weights(self, graph_data: HeteroData) -> torch.Tensor:
+        area_weights = self.global_area_weights(graph_data)
+        mask = graph_data[self.target]["cutout"].squeeze().bool()
+
+        global_sum = np.sum(area_weights[~mask])
+        weight_per_cutout_node = self.fraction * global_sum / sum(mask)
+        area_weights[mask] = weight_per_cutout_node
+
+        return torch.from_numpy(area_weights)

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -289,19 +289,16 @@ class GraphForecaster(pl.LightningModule):
                     LOGGER.debug("Parameter %s was not scaled.", key)
 
         return torch.from_numpy(loss_scaling)
-    
+
     @staticmethod
-    def get_node_weights(
-            config: DictConfig,
-            graph_data: HeteroData
-    ) -> torch.Tensor:
+    def get_node_weights(config: DictConfig, graph_data: HeteroData) -> torch.Tensor:
         node_weights = graph_data[config.graph.data][config.model.node_loss_weight].squeeze()
 
         if "spatial" in config.training.loss_scaling:
             spatial_loss_scaler = instantiate(config.training.loss_scaling.spatial)
             node_weights = spatial_loss_scaler.area_weights(graph_data)
             LOGGER.info("Rescaling area weights")
-        
+
         return node_weights
 
     def set_model_comm_group(self, model_comm_group: ProcessGroup) -> None:

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -86,7 +86,7 @@ class GraphForecaster(pl.LightningModule):
         self.save_hyperparameters()
 
         self.latlons_data = graph_data[config.graph.data].x
-        self.node_weights = graph_data[config.graph.data][config.model.node_loss_weight].squeeze()
+        self.node_weights = self.get_node_weights(config, graph_data)
 
         if config.model.get("output_mask", None) is not None:
             self.output_mask = Boolean1DMask(graph_data[config.graph.data][config.model.output_mask])
@@ -289,6 +289,20 @@ class GraphForecaster(pl.LightningModule):
                     LOGGER.debug("Parameter %s was not scaled.", key)
 
         return torch.from_numpy(loss_scaling)
+    
+    @staticmethod
+    def get_node_weights(
+            config: DictConfig,
+            graph_data: HeteroData
+    ) -> torch.Tensor:
+        node_weights = graph_data[config.graph.data][config.model.node_loss_weight].squeeze()
+
+        if "spatial" in config.training.loss_scaling:
+            spatial_loss_scaler = instantiate(config.training.loss_scaling.spatial)
+            node_weights = spatial_loss_scaler.area_weights(graph_data)
+            LOGGER.info("Rescaling area weights")
+        
+        return node_weights
 
     def set_model_comm_group(self, model_comm_group: ProcessGroup) -> None:
         LOGGER.debug("set_model_comm_group: %s", model_comm_group)


### PR DESCRIPTION
**Desctiption of functionality**
Adds functionality to change the area weighting of nodes in the limited area of a stretched grid graph.
Adds two new classes to scaling.py:
- BaseAreaWeights:
Uses scipy.SphericalVoronoi to calculate area weights based on latlon input grid similarly to how this is currently done in anemoi-graphs. Currently this probably won't have many use-cases since the area weights are already calculated like this in graphs, but it serves as a good base class.
- StretchedGridCutoutAreaWeights:
Re-calculates area-weights using BaseAreaWeights and then scales the area weights in the limited area (cutout) such that their sum is equal to a configurable fraction of the sum of global area weights. 

Adds staticmethod get_node_weights to GraphForecaster which uses the new scaling methods if they are set in the config.

**Configuration options**
Specified in config.training.loss_scaling.spatial, for instance:
training:
  loss_scaling:
    spatial:
      _target_: anemoi.training.data.scaling.StretchedGridCutoutAreaWeights
      target_nodes: ${graph.data}
      cutout_weight_frac_of_global: 0.3 
      
**Further comments**
- Based on the implementation of area-weights in the stretched grid branch of aifs-mono and https://github.com/ecmwf/anemoi-training/tree/feature/limited_area 
-  Functionality tested (together with stretched grid specific metrics from #130) https://mlflow.ecmwf.int/#/metric?runs=[%227c31b5334f524b78a74bbdd99d6f4bf6%22,%22e03701c4613745a884c9aae34e83d472%22]&metric=%22val_wmse_inside_lam_contribution_epoch%22&experiments=[%2230%22]&plot_metric_keys=%5B%22val_wmse_inside_lam_contribution_epoch%22%5D&plot_layout={%22autosize%22:true,%22xaxis%22:{%22range%22:[-3752.513985943475,19833.295466415468],%22autorange%22:false},%22yaxis%22:{%22range%22:[-0.01092616814456952,0.04189337908390672],%22autorange%22:false}}&x_axis=relative&y_axis_scale=linear&line_smoothness=1&show_point=false&deselected_curves=[]&last_linear_y_axis_range=[]

Thanks to Magnus Ingstad, Jasper Wijnands and Sophie Buurman and Mario Santa Cruz for their contributions to this PR. 
