### PR TITLE
feat: Add randomiser option to rollout

### DIFF
--- a/docs/modules/train.rst
+++ b/docs/modules/train.rst
@@ -16,6 +16,18 @@ forecaster that users may want to adapt to their own applications are:
 of the model is controlled. It also contains functions that enable the
 user to profile the training of the model (``profiler.py``).
 
+**Rollout**
+
+``training.rollout`` allows for configuration of the rollout of the
+model during training. A ``minimum/start``, ``maximum`` and
+``epoch_increment`` can be set. If ``epoch_increment`` is set to ``0``,
+the rollout will not be increased at all. Additionally, setting
+``randomise`` to ``True`` allows for a randomised rollout to be trained
+upon. If ``epoch_increment`` is set, the random value will be chosen
+between the current rollout step as altered by the increment and the
+``maximum``. If not set, the random value will be chosen between the
+``minimum/start`` and the ``maximum``.
+
 .. automodule:: anemoi.training.train.forecaster
    :members:
    :no-undoc-members:

--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -71,6 +71,8 @@ rollout:
   epoch_increment: 0
   # maximum rollout to use
   max: 1
+  # randomise rollout length during training
+  randomise: False
 
 # Set max_epochs or max_steps. Training stops at the first limit reached.
 max_epochs: null

--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -71,7 +71,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
         # Set the maximum rollout to be expected
         self.rollout = (
             self.config.training.rollout.max
-            if self.config.training.rollout.epoch_increment > 0
+            if self.config.training.rollout.epoch_increment > 0 or self.config.training.rollout.get("randomise", False)
             else self.config.training.rollout.start
         )
 


### PR DESCRIPTION
# Allow randomised rollout when training.

## Applications
- Prevent a model overfitting to a certain rollout
- Tune for various times

## Usage
Config file
```yaml
training:
  rollout:
    # randomise rollout length during training
    randomise: True
```

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--141.org.readthedocs.build/en/141/

<!-- readthedocs-preview anemoi-training end -->