### PR TITLE
dont check for tracking uri when running mlflow offline

### DIFF
--- a/src/anemoi/training/diagnostics/logger.py
+++ b/src/anemoi/training/diagnostics/logger.py
@@ -33,6 +33,8 @@ def get_mlflow_logger(config: DictConfig) -> None:
     forked = config.training.fork_run_id is not None
 
     save_dir = config.hardware.paths.logs.mlflow
+    
+    offline = config.diagnostics.log.mlflow.offline
     if not offline:
         tracking_uri = config.diagnostics.log.mlflow.tracking_uri
         LOGGER.info("AnemoiMLFlow logging to %s", tracking_uri)

--- a/src/anemoi/training/diagnostics/logger.py
+++ b/src/anemoi/training/diagnostics/logger.py
@@ -33,7 +33,7 @@ def get_mlflow_logger(config: DictConfig) -> None:
     forked = config.training.fork_run_id is not None
 
     save_dir = config.hardware.paths.logs.mlflow
-    
+
     offline = config.diagnostics.log.mlflow.offline
     if not offline:
         tracking_uri = config.diagnostics.log.mlflow.tracking_uri

--- a/src/anemoi/training/diagnostics/logger.py
+++ b/src/anemoi/training/diagnostics/logger.py
@@ -33,8 +33,11 @@ def get_mlflow_logger(config: DictConfig) -> None:
     forked = config.training.fork_run_id is not None
 
     save_dir = config.hardware.paths.logs.mlflow
-    tracking_uri = config.diagnostics.log.mlflow.tracking_uri
-    offline = config.diagnostics.log.mlflow.offline
+    if not offline:
+        tracking_uri = config.diagnostics.log.mlflow.tracking_uri
+        LOGGER.info("AnemoiMLFlow logging to %s", tracking_uri)
+    else:
+        tracking_uri = None
 
     if (resumed or forked) and (offline):  # when resuming or forking offline -
         # tracking_uri = ${hardware.paths.logs.mlflow}
@@ -54,7 +57,6 @@ def get_mlflow_logger(config: DictConfig) -> None:
         )
         log_hyperparams = False
 
-    LOGGER.info("AnemoiMLFlow logging to %s", tracking_uri)
     logger = AnemoiMLflowLogger(
         experiment_name=config.diagnostics.log.mlflow.experiment_name,
         project_name=config.diagnostics.log.mlflow.project_name,


### PR DESCRIPTION
The old behavior when running offline with the default tracking uri ('???') would cause a crash. So now tracking uri isnt checked when running offline

```python
    offline = config.diagnostics.log.mlflow.offline
    if not offline:
        tracking_uri = config.diagnostics.log.mlflow.tracking_uri
        LOGGER.info("AnemoiMLFlow logging to %s", tracking_uri)
    else:
        tracking_uri = None
```

My understanding is there is no reason to check tracking uri when running offline because tracking_uri is provided later if the run is synced to mlflow. 
One use case for running offline without a tracking uri would be for external vendors benchmarking anemoi. They could use the mlflow offline logging to analyse GPU utilization etc. 