### PR TITLE
added red gpu & increased green gpu monitoring

### DIFF
--- a/src/anemoi/training/diagnostics/mlflow/logger.py
+++ b/src/anemoi/training/diagnostics/mlflow/logger.py
@@ -433,56 +433,36 @@ class AnemoiMLflowLogger(MLFlowLogger):
     def log_system_metrics(self) -> None:
         """Log system metrics (CPU, GPU, etc)."""
         import mlflow
-        import psutil
-        from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
         from mlflow.system_metrics.metrics.disk_monitor import DiskMonitor
-        from mlflow.system_metrics.metrics.gpu_monitor import GPUMonitor
         from mlflow.system_metrics.metrics.network_monitor import NetworkMonitor
         from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
-        class CustomCPUMonitor(BaseMetricsMonitor):
-            """Class for monitoring CPU stats.
-
-            Extends default CPUMonitor, to also measure total \
-                    memory and a different formula for calculating used memory.
-
-            """
-
-            def collect_metrics(self) -> None:
-                # Get CPU metrics.
-                cpu_percent = psutil.cpu_percent()
-                self._metrics["cpu_utilization_percentage"].append(cpu_percent)
-
-                system_memory = psutil.virtual_memory()
-                # Change the formula for measuring CPU memory usage
-                # By default Mlflow uses psutil.virtual_memory().used
-                # Tests have shown that "used" underreports memory usage by as much as a factor of 2,
-                #   "used" also misses increased memory usage from using a higher prefetch factor
-                self._metrics["system_memory_usage_megabytes"].append(
-                    (system_memory.total - system_memory.available) / 1e6,
-                )
-                self._metrics["system_memory_usage_percentage"].append(system_memory.percent)
-
-                # QOL: report the total system memory in raw numbers
-                self._metrics["system_memory_total_megabytes"].append(system_memory.total / 1e6)
-
-            def aggregate_metrics(self) -> dict[str, int]:
-                return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}
+        from anemoi.training.diagnostics.mlflow.system_metrics.cpu_monitor import CPUMonitor
+        from anemoi.training.diagnostics.mlflow.system_metrics.gpu_monitor import GreenGPUMonitor
+        from anemoi.training.diagnostics.mlflow.system_metrics.gpu_monitor import RedGPUMonitor
 
         class CustomSystemMetricsMonitor(SystemMetricsMonitor):
             def __init__(self, run_id: str, resume_logging: bool = False):
                 super().__init__(run_id, resume_logging=resume_logging)
 
-                # Replace the CPUMonitor with custom implementation
-                self.monitors = [CustomCPUMonitor(), DiskMonitor(), NetworkMonitor()]
+                self.monitors = [CPUMonitor(), DiskMonitor(), NetworkMonitor()]
+
+                # I dont know any way to check if the GPU is red or green
+                # So, try init both and catch the error when one init fails
                 try:
-                    gpu_monitor = GPUMonitor()
+                    gpu_monitor = GreenGPUMonitor()
                     self.monitors.append(gpu_monitor)
-                except ImportError:
-                    LOGGER.warning(
-                        "`pynvml` is not installed, to log GPU metrics please run `pip install pynvml` \
-                            to install it",
-                    )
+                except RuntimeError as e:
+                    LOGGER.warning("Failed to init Green GPU Monitor: %s", e)
+                except ImportError as e:
+                    LOGGER.warning("Failed to init Green GPU Monitor: %s", e)
+                try:
+                    gpu_monitor = RedGPUMonitor()
+                    self.monitors.append(gpu_monitor)
+                except RuntimeError as e:
+                    LOGGER.warning("Failed to init Red GPU Monitor: %s", e)
+                except ImportError as e:
+                    LOGGER.warning("Failed to init Red GPU Monitor: %s", e)
 
         mlflow.enable_system_metrics_logging()
         system_monitor = CustomSystemMetricsMonitor(

--- a/src/anemoi/training/diagnostics/mlflow/system_metrics/cpu_monitor.py
+++ b/src/anemoi/training/diagnostics/mlflow/system_metrics/cpu_monitor.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import psutil
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+
+class CPUMonitor(BaseMetricsMonitor):
+    """Class for monitoring CPU stats.
+
+    Extends default CPUMonitor, to also measure total \
+            memory and a different formula for calculating used memory.
+
+    """
+
+    def collect_metrics(self) -> None:
+        # Get CPU metrics.
+        cpu_percent = psutil.cpu_percent()
+        self._metrics["cpu_utilization_percentage"].append(cpu_percent)
+
+        system_memory = psutil.virtual_memory()
+        # Change the formula for measuring CPU memory usage
+        # By default Mlflow uses psutil.virtual_memory().used
+        # Tests have shown that "used" underreports memory usage by as much as a factor of 2,
+        #   "used" also misses increased memory usage from using a higher prefetch factor
+        self._metrics["system_memory_usage_megabytes"].append(
+            (system_memory.total - system_memory.available) / 1e6,
+        )
+        self._metrics["system_memory_usage_percentage"].append(system_memory.percent)
+
+        # QOL: report the total system memory in raw numbers
+        self._metrics["system_memory_total_megabytes"].append(system_memory.total / 1e6)
+
+    def aggregate_metrics(self) -> dict[str, int]:
+        return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}

--- a/src/anemoi/training/diagnostics/mlflow/system_metrics/gpu_monitor.py
+++ b/src/anemoi/training/diagnostics/mlflow/system_metrics/gpu_monitor.py
@@ -1,0 +1,125 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import contextlib
+import sys
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+with contextlib.suppress(ImportError):
+    import pynvml
+with contextlib.suppress(ImportError):
+    from pyrsmi import rocml
+
+
+class GreenGPUMonitor(BaseMetricsMonitor):
+    """Class for monitoring green GPU stats.
+
+    Requires pynvml to be installed.
+    Extends default GPUMonitor, to also measure total \
+            memory
+
+    """
+
+    def __init__(self):
+        if "pynvml" not in sys.modules:
+            # Only instantiate if `pynvml` is installed.
+            import_error_msg = "`pynvml` is not installed, to log green GPU metrics please run `pip install pynvml`."
+            raise ImportError(import_error_msg)
+        try:
+            # `nvmlInit()` will fail if no GPU is found.
+            pynvml.nvmlInit()
+        except pynvml.NVMLError as e:
+            runtime_error_msg = "Failed to initalize Red GPU monitor: "
+            raise RuntimeError(runtime_error_msg) from e
+
+        super().__init__()
+        self.num_gpus = pynvml.nvmlDeviceGetCount()
+        self.gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(self.num_gpus)]
+
+    def collect_metrics(self) -> None:
+        # Get GPU metrics.
+        for i, handle in enumerate(self.gpu_handles):
+            memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            self._metrics[f"gpu_{i}_memory_usage_percentage"].append(
+                round(memory.used / memory.total * 100, 1),
+            )
+            self._metrics[f"gpu_{i}_memory_usage_megabytes"].append(memory.used / 1e6)
+
+            # Only record total device memory on GPU 0 to prevent spam
+            # Unlikely for GPUs on the same node to have different total memory
+            if i == 0:
+                self._metrics["gpu_memory_total_megabytes"].append(memory.total / 1e6)
+
+            # Monitor PCIe usage
+            tx_kilobytes = pynvml.nvmlDeviceGetPcieThroughput(handle, pynvml.NVML_PCIE_UTIL_TX_BYTES)
+            rx_kilobytes = pynvml.nvmlDeviceGetPcieThroughput(handle, pynvml.NVML_PCIE_UTIL_RX_BYTES)
+            self._metrics[f"gpu_{i}_pcie_tx_megabytes"].append(tx_kilobytes / 1e3)
+            self._metrics[f"gpu_{i}_pcie_rx_megabytes"].append(rx_kilobytes / 1e3)
+
+            device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
+            self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization.gpu)
+
+            power_milliwatts = pynvml.nvmlDeviceGetPowerUsage(handle)
+            power_capacity_milliwatts = pynvml.nvmlDeviceGetEnforcedPowerLimit(handle)
+            self._metrics[f"gpu_{i}_power_usage_watts"].append(power_milliwatts / 1000)
+            self._metrics[f"gpu_{i}_power_usage_percentage"].append(
+                (power_milliwatts / power_capacity_milliwatts) * 100,
+            )
+
+    def aggregate_metrics(self) -> dict[str, int]:
+        return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}
+
+
+class RedGPUMonitor(BaseMetricsMonitor):
+    """Class for monitoring red GPU stats.
+
+    Requires that pyrsmi is installed
+    Logs utilization and memory usage.
+
+    """
+
+    def __init__(self):
+        if "pyrsmi" not in sys.modules:
+            import_error_msg = "`pyrsmi` is not installed, to log red GPU metrics please run `pip install pyrsmi`."
+            # Only instantiate if `pyrsmi` is installed.
+            raise ImportError(import_error_msg)
+        try:
+            # `rocml.smi_initialize()()` will fail if no GPU is found.
+            rocml.smi_initialize()
+        except RuntimeError as e:
+            runtime_error_msg = "Failed to initalize Red GPU monitor: "
+            raise RuntimeError(runtime_error_msg) from e
+
+        super().__init__()
+        self.num_gpus = rocml.smi_get_device_count()
+
+    def collect_metrics(self) -> None:
+        # Get GPU metrics.
+        for device in range(self.num_gpus):
+            memory_used = rocml.smi_get_device_memory_used(device)
+            memory_total = rocml.smi_get_device_memory_total(device)
+            memory_busy = rocml.smi_get_device_memory_busy(device)
+            self._metrics[f"gpu_{device}_memory_usage_percentage"].append(
+                round(memory_used / memory_total * 100, 1),
+            )
+            self._metrics[f"gpu_{device}_memory_usage_megabytes"].append(memory_used / 1e6)
+
+            self._metrics[f"gpu_{device}_memory_busy_percentage"].append(memory_busy)
+
+            # Only record total device memory on GPU 0 to prevent spam
+            # Unlikely for GPUs on the same node to have different total memory
+            if device == 0:
+                self._metrics["gpu_memory_total_megabytes"].append(memory_total / 1e6)
+
+            utilization = rocml.smi_get_device_utilization(device)
+            self._metrics[f"gpu_{device}_utilization_percentage"].append(utilization)
+
+    def aggregate_metrics(self) -> dict[str, int]:
+        return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}


### PR DESCRIPTION
This PR adds a GPU monitor for Red GPUs which tracks memory usage and GPU utilisation. Tested on LUMI and it works. 

I also added some more metrics to the Green GPU logger, so now PCIe usage and total device memory are tracked.

![gpu_mem_usage](https://github.com/user-attachments/assets/d3036a30-8007-4b5a-b7bf-043208c1d799)

As part of this PR, I moved the CPU and GPU monitor code into their own files under diagnostics/mlflow/system_metrics

