### PR TITLE
150 n320 callback number of pixels used by datashader

### DIFF
--- a/src/anemoi/training/diagnostics/plots.py
+++ b/src/anemoi/training/diagnostics/plots.py
@@ -696,7 +696,7 @@ def single_plot(
     else:
         df = pd.DataFrame({"val": data, "x": lon, "y": lat})
         # Adjust binning to match the resolution of the data
-        n_pixels = int(np.floor(data.shape[0] / 212))
+        n_pixels = min(int(np.floor(data.shape[0] * 0.004)), 500)
         psc = dsshow(
             df,
             dsh.Point("x", "y"),


### PR DESCRIPTION
PR to fix https://github.com/ecmwf/anemoi-training/issues/150
Propose change - make the 'n_pixels' more flexible so that  when using finer resolutions (like n32),  500 as `n_pixels` should be enough, but for hidden grid plots and coarser ones then we need to use way less, so the other condition would apply. 

