### PR TITLE
Validation and Training dataset dates assertion

### DIFF
--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -142,10 +142,12 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
     def ds_valid(self) -> NativeGridDataset:
         r = max(self.rollout, self.config.dataloader.get("validation_rollout", 1))
 
-        assert self.config.dataloader.training.end < self.config.dataloader.validation.start, (
-            f"Training end date {self.config.dataloader.training.end} is not before"
-            f"validation start date {self.config.dataloader.validation.start}"
-        )
+        if not self.config.dataloader.training.end < self.config.dataloader.validation.start:
+            LOGGER.info(
+                "Training end date %s is not before validation start date %s.",
+                self.config.dataloader.training.end,
+                self.config.dataloader.validation.start,
+            )
         return self._get_dataset(
             open_dataset(OmegaConf.to_container(self.config.dataloader.validation, resolve=True)),
             shuffle=False,

--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -117,7 +117,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
         r = max(self.rollout, self.config.dataloader.get("validation_rollout", 1))
 
         if not self.config.dataloader.training.end < self.config.dataloader.validation.start:
-            LOGGER.info(
+            LOGGER.warning(
                 "Training end date %s is not before validation start date %s.",
                 self.config.dataloader.training.end,
                 self.config.dataloader.validation.start,


### PR DESCRIPTION
Currently, the code uses an assertion to ensure that the validation dataset's start date occurs after the training dataset's end date. However, this check should issue a warning instead of being a blocking assertion. 