### PR TITLE
Feature: Temporal interpolation

### DIFF
--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -100,7 +100,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
     def relative_date_indices(self) -> list:
         """Determine a list of relative time indices to load for each batch"""
         if hasattr(self.config.training, "explicit_times"):
-            return sorted(self.config.training.explicit_times.input + self.config.training.explicit_times.target)
+            return sorted(set(self.config.training.explicit_times.input + self.config.training.explicit_times.target))
         
         else: #uses the old default of multistep, timeincrement and rollout.
             # Use the maximum rollout to be expected

--- a/src/anemoi/training/train/interpolator.py
+++ b/src/anemoi/training/train/interpolator.py
@@ -1,0 +1,118 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import logging
+import math
+import os
+from collections import defaultdict
+from collections.abc import Generator
+from collections.abc import Mapping
+from typing import Optional
+from typing import Union
+from operator import itemgetter
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+from anemoi.models.data_indices.collection import IndexCollection
+from anemoi.models.interface import AnemoiModelInterface
+from anemoi.utils.config import DotDict
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from omegaconf import OmegaConf
+from timm.scheduler import CosineLRScheduler
+from torch.distributed.distributed_c10d import ProcessGroup
+from torch.distributed.optim import ZeroRedundancyOptimizer
+from torch.utils.checkpoint import checkpoint
+from torch_geometric.data import HeteroData
+
+from anemoi.training.losses.utils import grad_scaler
+from anemoi.training.losses.weightedloss import BaseWeightedLoss
+from anemoi.training.utils.jsonify import map_config_to_primitives
+from anemoi.training.utils.masks import Boolean1DMask
+from anemoi.training.utils.masks import NoOutputMask
+
+from anemoi.training.train.forecaster import GraphForecaster
+
+LOGGER = logging.getLogger(__name__)
+
+class GraphInterpolator(GraphForecaster):
+    """Graph neural network interpolator for PyTorch Lightning."""
+
+    def __init__(
+        self,
+        *,
+        config: DictConfig,
+        graph_data: HeteroData,
+        statistics: dict,
+        data_indices: IndexCollection,
+        metadata: dict,
+    ) -> None:
+        """Initialize graph neural network interpolator.
+
+        Parameters
+        ----------
+        config : DictConfig
+            Job configuration
+        graph_data : HeteroData
+            Graph object
+        statistics : dict
+            Statistics of the training data
+        data_indices : IndexCollection
+            Indices of the training data,
+        metadata : dict
+            Provenance information
+
+        """
+        super().__init__(config = config, graph_data = graph_data, statistics = statistics, data_indices = data_indices, metadata = metadata)
+        self.target_forcing_indices = itemgetter(*config.training.target_forcing.data)(data_indices.data.input.name_to_index)
+        self.boundary_times = config.training.explicit_times.input
+        self.interp_times = config.training.explicit_times.target
+
+
+    def _step(
+        self,
+        batch: torch.Tensor,
+        batch_idx: int,
+        validation_mode: bool = False,
+    ) -> tuple[torch.Tensor, Mapping[str, torch.Tensor]]:
+        
+        del batch_idx
+        loss = torch.zeros(1, dtype=batch.dtype, device=self.device, requires_grad=False)
+        metrics = {}
+        y_preds = []
+
+        batch = self.model.pre_processors(batch)
+        x_bound = batch[:, self.boundary_times][..., self.data_indices.data.input.full] # (bs, time, ens, latlon, nvar)
+
+        tfi = self.target_forcing_indices
+        target_forcing = torch.empty(batch.shape[0], batch.shape[2], batch.shape[3], len(tfi)+1, device = self.device, dtype = batch.dtype)
+        for interp_step in self.interp_times:
+            #get the forcing information for the target interpolation time:
+            target_forcing[..., :len(tfi)] = batch[:, interp_step, :, :, tfi]
+            target_forcing[..., -1] = (interp_step - self.boundary_times[0])/(self.boundary_times[1] - self.boundary_times[0])
+            #TODO: make fraction time one of a config given set of arbitrary custom forcing functions.
+
+            y_pred = self(x_bound, target_forcing)
+            y = batch[:, interp_step, :, :, self.data_indices.data.output.full]
+
+            loss += checkpoint(self.loss, y_pred, y, use_reentrant=False)
+
+            metrics_next = {}
+            if validation_mode:
+                metrics_next = self.calculate_val_metrics(y_pred, y, interp_step-1) #expects rollout but can be repurposed here.
+            metrics.update(metrics_next)
+            y_preds.extend(y_pred)
+
+        loss *= 1.0 / len(self.interp_times)
+        return loss, metrics, y_preds
+    
+    def forward(self, x: torch.Tensor, target_forcing: torch.Tensor) -> torch.Tensor:
+        return self.model(x, target_forcing, self.model_comm_group)

--- a/src/anemoi/training/utils/usable_indices.py
+++ b/src/anemoi/training/utils/usable_indices.py
@@ -16,9 +16,7 @@ import numpy as np
 def get_usable_indices(
     missing_indices: set[int] | None,
     series_length: int,
-    rollout: int,
-    multistep: int,
-    timeincrement: int = 1,
+    relative_indices: np.ndarray,
 ) -> np.ndarray:
     """Get the usable indices of a series whit missing indices.
 
@@ -28,32 +26,24 @@ def get_usable_indices(
         Dataset to be used.
     series_length : int
         Length of the series.
-    rollout : int
-        Number of steps to roll out.
-    multistep : int
-        Number of previous indices to include as predictors.
-    timeincrement : int
-        Time increment, by default 1.
+    relative_indices:
+        Array of relative indices requested at each index i.
 
     Returns
     -------
     usable_indices : np.array
         Array of usable indices.
     """
-    prev_invalid_dates = (multistep - 1) * timeincrement
-    next_invalid_dates = rollout * timeincrement
-
     usable_indices = np.arange(series_length)  # set of all indices
 
     if missing_indices is None:
         missing_indices = set()
 
-    missing_indices |= {-1, series_length}  # to filter initial and final indices
+    missing_indices |= {series_length} #filter final index
 
     # Missing indices
     for i in missing_indices:
-        usable_indices = usable_indices[
-            (usable_indices < i - next_invalid_dates) + (usable_indices > i + prev_invalid_dates)
-        ]
+        rel_missing = i - relative_indices #indices which have their relative indices match the missing.
+        usable_indices = usable_indices[np.all(usable_indices != rel_missing[:,np.newaxis], axis = 0)]
 
     return usable_indices

--- a/src/anemoi/training/utils/usable_indices.py
+++ b/src/anemoi/training/utils/usable_indices.py
@@ -39,7 +39,7 @@ def get_usable_indices(
     if missing_indices is None:
         missing_indices = set()
 
-    missing_indices |= {series_length} #filter final index
+    missing_indices |= set(range(series_length, series_length + max(relative_indices) + 1)) #filter indices larger than series length
 
     # Missing indices
     for i in missing_indices:

--- a/tests/utils/test_usable_indices.py
+++ b/tests/utils/test_usable_indices.py
@@ -16,33 +16,37 @@ from anemoi.training.utils.usable_indices import get_usable_indices
 def test_get_usable_indices() -> None:
     """Test get_usable_indices function."""
     # Test base case
-    valid_indices = get_usable_indices(missing_indices=None, series_length=10, rollout=1, multistep=1, timeincrement=1)
+    valid_indices = get_usable_indices(missing_indices=None, series_length=10, relative_indices = np.array([0, 1]))
+    print(valid_indices)
     expected_values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
     assert np.allclose(valid_indices, expected_values)
 
-    # Test multiple steps inputs
-    valid_indices = get_usable_indices(missing_indices=None, series_length=10, rollout=1, multistep=2, timeincrement=1)
-    expected_values = np.array([1, 2, 3, 4, 5, 6, 7, 8])
-    assert np.allclose(valid_indices, expected_values)
-
-    # Test roll out
-    valid_indices = get_usable_indices(missing_indices=None, series_length=10, rollout=2, multistep=1, timeincrement=1)
+    # Test 3 indices, either from rollout = 1 and multistep = 2, or rollout = 2 and multistep = 1
+    valid_indices = get_usable_indices(missing_indices=None, series_length=10, relative_indices = np.array([0, 1, 2]))
     expected_values = np.array([0, 1, 2, 3, 4, 5, 6, 7])
     assert np.allclose(valid_indices, expected_values)
 
-    # Test longer time increments
-    valid_indices = get_usable_indices(missing_indices=None, series_length=10, rollout=1, multistep=2, timeincrement=2)
-    expected_values = np.array([2, 3, 4, 5, 6, 7])
+    # With time increment
+    valid_indices = get_usable_indices(missing_indices=None, series_length=10, relative_indices = np.array([0, 2, 4]))
+    print(valid_indices)
+    expected_values = np.array([0, 1, 2, 3, 4, 5])
     assert np.allclose(valid_indices, expected_values)
 
-    # Test missing indices
-    missing_indices = {7, 5}
+    # Test missing indices with standard setup
+    missing_indices = {7, 5, 14}
     valid_indices = get_usable_indices(
         missing_indices=missing_indices,
-        series_length=10,
-        rollout=1,
-        multistep=2,
-        timeincrement=1,
+        series_length=20,
+        relative_indices = np.array([0, 1, 2])
     )
-    expected_values = np.array([1, 2, 3])
+    expected_values = np.array([0, 1, 2, 8, 9, 10, 11, 15, 16, 17])
+    assert np.allclose(valid_indices, expected_values)
+
+    #Now verify that with a non-standard setup, missing indices can be "jumped" over.
+    valid_indices = get_usable_indices(
+        missing_indices = missing_indices,
+        series_length = 20,
+        relative_indices = np.array([0, 5, 6, 7]) #e.g making a 1 hour forecast based on -6, -1 and 0 hours.
+    )
+    expected_values = np.array([3, 4, 6, 10, 11, 12])
     assert np.allclose(valid_indices, expected_values)


### PR DESCRIPTION
Adds temporal interpolation functionality to anemoi. The idea is that a 6 or 12 hour forecaster might yield better predictions going days out than a 1 hour forecaster, as it has to make fewer auto-regressive steps. To produce the hourly predictions still, we can use the information available from the forecaster, e.g. hours 12 and 18 as input to predict hours 13-17. These predictions are made individually, assisted by some information about the target time as input.

This is a work in progress, parts of the implementation can be found on the corresponding branch of anemoi-models.

**Implemented**
- A prototype that runs (with decreasing loss, but haven't done any full scale training to verify yet). The interpolator itself is implemented as GraphInterpolator in interpolator.py, with train.py generalized to call a config-based model. If nothing is specified, it defaults to GraphForecaster.
- The config options multistep and rollout are not applicable to the interpolation case, so I added the option to explicitly state which time steps to use as input, and as a target for the model. This also enables non-regular input for the forecaster, e.g. using input at 0, -1, and -6 hours to make a 1 hour forecast.
- A corresponding change in the valid dates function, which also includes the possibility for data to be extracted across missing dates if the requested indices can cross the gap. E.g. with a missing date at index 8, and requested dates at 0,3,6. Indices 3,4 and 6,7 are still usable, which would not have been represented correctly before.
- Option to add temporal forcings at the target time as an input to the model, this is necessary for interpolation at multiple distinct hours with the same model weights. 

**To do**
- Add support for custom forcing parameters beyond those in the dataset. As of now, only the target time as a fractional difference between the input times is possible and used by default. I will instead move this to a config instantiated object.
- Run a full scale training and compare with previous results (from the old aifs-mono where I first implemented this)
- Also do a short training with the forecaster and see that the results are as expected.
- Implement a way to avoid crossing model runs. When training on data with analysis less frequent than the target interpolation frequency, one has to switch between different model runs at certain points in the dataset. If we for instance use 18 continuous hours of a run before switching, the change from hour 29 of one run to hour 12 of the next run will not represent a physical change in the state of the atmosphere. To avoid training on this, we thus need to consider all sets of inputs and targets that will cross this gap as invalid. I will add this to the usable_indices function.

**Questions**
- In train.py I could not get instantiate to work as an instance of the forecaster/interpolator because "config" is a kwarg of instantiate itself, and thus cannot be included in the additional kwargs. Instead I used a combination of importlib and getattr, but if there is a way to use instantiate here, I can replace it.
- Does anemoi datasets not support extracting dates with irregular indices? I could not get open_dataset to work with indices that do not follow a regular sliceable pattern. Either with an array or a tuple/list of indices. Is there a way around this?
Although a simple interpolation setup like using hours 0 and 6 to predict hours 1-5 yields a regular range from 0 to 6, irregular ranges would enable more complex setups for both the forecaster and interpolator.