### PR TITLE
Store numpy arrays in checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased](https://github.com/ecmwf/anemoi-training/compare/0.3.1...HEAD)
 
+### Added
+
+- Add supporting arrrays (numpy) to checkpoint
+
 ## [0.3.1 - AIFS v0.3 Compatibility](https://github.com/ecmwf/anemoi-training/compare/0.3.0...0.3.1) - 2024-11-28
 
 ### Fixed

--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -74,6 +74,10 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
         return self.ds_train.metadata
 
     @cached_property
+    def supporting_arrays(self) -> dict:
+        return self.ds_train.supporting_arrays
+
+    @cached_property
     def data_indices(self) -> IndexCollection:
         return IndexCollection(self.config, self.ds_train.name_to_index)
 

--- a/src/anemoi/training/data/datamodule.py
+++ b/src/anemoi/training/data/datamodule.py
@@ -79,7 +79,7 @@ class AnemoiDatasetsDataModule(pl.LightningDataModule):
 
     @cached_property
     def supporting_arrays(self) -> dict:
-        return self.ds_train.supporting_arrays
+        return self.ds_train.supporting_arrays | self.grid_indices.supporting_arrays
 
     @cached_property
     def data_indices(self) -> IndexCollection:

--- a/src/anemoi/training/data/dataset.py
+++ b/src/anemoi/training/data/dataset.py
@@ -101,6 +101,11 @@ class NativeGridDataset(IterableDataset):
         return self.data.metadata()
 
     @cached_property
+    def supporting_arrays(self) -> dict:
+        """Return dataset supporting_arrays."""
+        return self.data.supporting_arrays()
+
+    @cached_property
     def name_to_index(self) -> dict:
         """Return dataset statistics."""
         return self.data.name_to_index

--- a/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -149,16 +149,22 @@ class AnemoiCheckpoint(ModelCheckpoint):
             tmp_metadata = model.metadata
             model.metadata = None
 
-            metadata = dict(**tmp_metadata)
+            tmp_supporting_arrays = model.supporting_arrays
+            model.supporting_arrays = None
+
+            # Make sure we don't accidentally modidy these
+            metadata = tmp_metadata.copy()
+            supporting_arrays = tmp_supporting_arrays.copy()
 
             inference_checkpoint_filepath = self._get_inference_checkpoint_filepath(lightning_checkpoint_filepath)
 
             torch.save(model, inference_checkpoint_filepath)
 
-            save_metadata(inference_checkpoint_filepath, metadata)
+            save_metadata(inference_checkpoint_filepath, metadata, supporting_arrays=supporting_arrays)
 
             model.config = save_config
             model.metadata = tmp_metadata
+            model.supporting_arrays = tmp_supporting_arrays
 
             self._last_global_step_saved = trainer.global_step
 

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -50,6 +50,7 @@ class GraphForecaster(pl.LightningModule):
         statistics: dict,
         data_indices: IndexCollection,
         metadata: dict,
+        supporting_arrays: dict,
     ) -> None:
         """Initialize graph neural network forecaster.
 
@@ -65,6 +66,8 @@ class GraphForecaster(pl.LightningModule):
             Indices of the training data,
         metadata : dict
             Provenance information
+        supporting_arrays : dict
+            Supporting NumPy arrays to store in the checkpoint
 
         """
         super().__init__()
@@ -75,6 +78,7 @@ class GraphForecaster(pl.LightningModule):
             statistics=statistics,
             data_indices=data_indices,
             metadata=metadata,
+            supporting_arrays=supporting_arrays,
             graph_data=graph_data,
             config=DotDict(map_config_to_primitives(OmegaConf.to_container(config, resolve=True))),
         )

--- a/src/anemoi/training/train/train.py
+++ b/src/anemoi/training/train/train.py
@@ -144,6 +144,7 @@ class AnemoiTrainer:
             "graph_data": self.graph_data,
             "metadata": self.metadata,
             "statistics": self.datamodule.statistics,
+            "supporting_arrays": self.supporting_arrays,
         }
         if self.load_weights_only:
             LOGGER.info("Restoring only model weights from %s", self.last_checkpoint)
@@ -230,6 +231,10 @@ class AnemoiTrainer:
                 "timestamp": datetime.datetime.now(tz=datetime.timezone.utc),
             },
         )
+
+    @cached_property
+    def supporting_arrays(self) -> dict:
+        return self.datamodule.supporting_arrays
 
     @cached_property
     def profiler(self) -> PyTorchProfiler | None:

--- a/src/anemoi/training/utils/masks.py
+++ b/src/anemoi/training/utils/masks.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 class BaseMask:
     """Base class for masking model output."""
 
+    @property
+    def supporting_arrays(self) -> dict:
+        return {}
+
     @abstractmethod
     def apply(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         error_message = "Method `apply` must be implemented in subclass."
@@ -38,6 +42,10 @@ class Boolean1DMask(BaseMask):
 
     def __init__(self, values: torch.Tensor) -> None:
         self.mask = values.bool().squeeze()
+
+    @property
+    def supporting_arrays(self) -> dict:
+        return {"output_mask": self.mask.numpy()}
 
     def broadcast_like(self, x: torch.Tensor, dim: int) -> torch.Tensor:
         assert x.shape[dim] == len(

--- a/tests/diagnostics/test_checkpoint.py
+++ b/tests/diagnostics/test_checkpoint.py
@@ -36,6 +36,7 @@ class DummyModel(torch.nn.Module):
 
         self.config = config
         self.metadata = metadata
+        self.supporting_arrays = {}
         self.fc1 = nn.Linear(32, 5)
         self.fc2 = nn.Linear(5, 1)
         self.relu = nn.ReLU()


### PR DESCRIPTION
We add to the checkpoint the latitudes, longitudes, and any other supporting bumpy arrays (e.g. masks)