### PR TITLE
fix weight mask calculation when using the remapper and no imputer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Keep it human-readable, your future self will thank you!
 
 - Allow histogram and spectrum plot for one variable [#165](https://github.com/ecmwf/anemoi-training/pull/165)
 
+- Not update NaN-weight-mask for loss function when using remapper and no imputer
 
 ### Added
 

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -229,12 +229,14 @@ class GraphForecaster(pl.LightningModule):
         """Update the loss weights mask for imputed variables."""
         if "loss_weights_mask" in self.loss.scalar:
             loss_weights_mask = torch.ones((1, 1), device=batch.device)
+            found_loss_mask_training = False
             # iterate over all pre-processors and check if they have a loss_mask_training attribute
             for pre_processor in self.model.pre_processors.processors.values():
                 if hasattr(pre_processor, "loss_mask_training"):
                     loss_weights_mask = loss_weights_mask * pre_processor.loss_mask_training
+                    found_loss_mask_training = True
                 # if transform_loss_mask function exists for preprocessor apply it
-                if hasattr(pre_processor, "transform_loss_mask"):
+                if hasattr(pre_processor, "transform_loss_mask") and found_loss_mask_training:
                     loss_weights_mask = pre_processor.transform_loss_mask(loss_weights_mask)
             # update scaler with loss_weights_mask retrieved from preprocessors
             self.loss.update_scalar(scalar=loss_weights_mask.cpu(), name="loss_weights_mask")


### PR DESCRIPTION
Using the remapper without the imputer leads to an error as the code is trying to update the loss-function-scalar, which weights imputed NaN positions with zero. This updating should only take place if an imputer is used, otherwise, the weight-mask is of the wrong shape.