### PR TITLE
[PROFILER] dont crash if an env var isnt found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Keep it human-readable, your future self will thank you!
 ## [Unreleased](https://github.com/ecmwf/anemoi-training/compare/0.3.1...HEAD)
 ### Fixed
 - Not update NaN-weight-mask for loss function when using remapper and no imputer [#178](https://github.com/ecmwf/anemoi-training/pull/178)
+- Dont crash when using the profiler if certain env vars arent set [#180](https://github.com/ecmwf/anemoi-training/pull/180)
 
 ### Added
 - Added a check for the variable sorting on pre-trained/finetuned models [#120](https://github.com/ecmwf/anemoi-training/pull/120)

--- a/src/anemoi/training/train/profiler.py
+++ b/src/anemoi/training/train/profiler.py
@@ -57,8 +57,8 @@ class AnemoiProfiler(AnemoiTrainer):
 
     @staticmethod
     def print_metadata() -> None:
-        console.print(f"[bold blue] SLURM NODE(s) {os.environ['HOST']} [/bold blue]!")
-        console.print(f"[bold blue] SLURM JOB ID {os.environ['SLURM_JOB_ID']} [/bold blue]!")
+        console.print(f"[bold blue] SLURM NODE(s) {os.getenv('SLURM_JOB_NODELIST', '')} [/bold blue]!")
+        console.print(f"[bold blue] SLURM JOB ID {os.getenv('SLURM_JOB_ID', '')} [/bold blue]!")
         console.print(f"[bold blue] TIMESTAMP {datetime.now(timezone.utc).strftime('%d/%m/%Y %H:%M:%S')} [/bold blue]!")
 
     @rank_zero_only


### PR DESCRIPTION
Fall back to an empty string if env vars arent found when writing the profiler report. Otherwise you would get an error right at the end of your job