### PR TITLE
fix: allow None as graph save_path setting.

### DIFF
--- a/src/anemoi/training/train/train.py
+++ b/src/anemoi/training/train/train.py
@@ -118,14 +118,18 @@ class AnemoiTrainer:
 
         Creates the graph in all workers.
         """
-        graph_filename = Path(
-            self.config.hardware.paths.graph,
-            self.config.hardware.files.graph,
-        )
+        if self.config.hardware.files.graph is not None:
+            graph_filename = Path(
+                self.config.hardware.paths.graph,
+                self.config.hardware.files.graph,
+            )
 
-        if graph_filename.exists() and not self.config.graph.overwrite:
-            LOGGER.info("Loading graph data from %s", graph_filename)
-            return torch.load(graph_filename)
+            if graph_filename.exists() and not self.config.graph.overwrite:
+                LOGGER.info("Loading graph data from %s", graph_filename)
+                return torch.load(graph_filename)
+
+        else:
+            graph_filename = None
 
         from anemoi.graphs.create import GraphCreator
 


### PR DESCRIPTION
This small changeset fixes the `save_path` option:
- the `anemoi-graphs` package accepts `None`, see https://github.com/ecmwf/anemoi-graphs/blob/fc614171f45e757b14bac92188c4d0b785e41e46/src/anemoi/graphs/create.py#L183 
- the `anemoi-training` just passes a `None` setting from the hydra YAML now.
