### PR TITLE
Fixes to callback plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Keep it human-readable, your future self will thank you!
 - Not update NaN-weight-mask for loss function when using remapper and no imputer [#178](https://github.com/ecmwf/anemoi-training/pull/178)
 - Dont crash when using the profiler if certain env vars arent set [#180](https://github.com/ecmwf/anemoi-training/pull/180)
 - Remove saving of metadata to training checkpoint [#57](https://github.com/ecmwf/anemoi-training/pull/190)
+- Fixes to callback plots [#182] (power spectrum large numpy array error + precip cmap for cases where precip is prognostic).
 
 ### Added
 - Introduce variable to configure: transfer_learning -> bool, True if loading checkpoint in a transfer learning setting.

--- a/src/anemoi/training/config/diagnostics/plot/detailed.yaml
+++ b/src/anemoi/training/config/diagnostics/plot/detailed.yaml
@@ -44,6 +44,7 @@ callbacks:
 
   - _target_: anemoi.training.diagnostics.callbacks.plot.PlotSpectrum
     # every_n_batches: 100 # Override for batch frequency
+    # min_delta: 0.01 # Minimum distance between two consecutive points
     sample_idx: ${diagnostics.plot.sample_idx}
     parameters:
     - z_500

--- a/src/anemoi/training/diagnostics/callbacks/plot.py
+++ b/src/anemoi/training/diagnostics/callbacks/plot.py
@@ -1018,6 +1018,7 @@ class PlotSpectrum(BasePlotAdditionalMetrics):
         config: OmegaConf,
         sample_idx: int,
         parameters: list[str],
+        min_delta: float | None = None,
         every_n_batches: int | None = None,
     ) -> None:
         """Initialise the PlotSpectrum callback.
@@ -1036,6 +1037,7 @@ class PlotSpectrum(BasePlotAdditionalMetrics):
         super().__init__(config, every_n_batches=every_n_batches)
         self.sample_idx = sample_idx
         self.parameters = parameters
+        self.min_delta = min_delta
 
     @rank_zero_only
     def _plot(
@@ -1070,6 +1072,7 @@ class PlotSpectrum(BasePlotAdditionalMetrics):
                 data[0, ...].squeeze(),
                 data[rollout_step + 1, ...].squeeze(),
                 output_tensor[rollout_step, ...],
+                min_delta=self.min_delta,
             )
 
             self._output_figure(

--- a/src/anemoi/training/diagnostics/plots.py
+++ b/src/anemoi/training/diagnostics/plots.py
@@ -182,8 +182,9 @@ def plot_power_spectrum(
     min_delta_lat = np.min(abs(non_zero_delta_lat))
 
     if min_delta_lat < min_delta:
-        logging.warning(
-            f"Minimum distance between lat/lon points is less than the specified minimum distance. Defaulting to min_delta={min_delta}."
+        LOGGER.warning(
+            "Minimum distance between lat/lon points is less than the specified minimum distance. Defaulting to min_delta=%s.",
+            min_delta,
         )
         min_delta_lat = min_delta
 

--- a/src/anemoi/training/diagnostics/plots.py
+++ b/src/anemoi/training/diagnostics/plots.py
@@ -157,6 +157,8 @@ def plot_power_spectrum(
         Expected data of shape (lat*lon, nvar*level)
     y_pred : np.ndarray
         Predicted data of shape (lat*lon, nvar*level)
+    min_delta: float, optional
+        Minimum distance between lat/lon points, if None defaulted to 1km
 
     Returns
     -------
@@ -183,7 +185,7 @@ def plot_power_spectrum(
 
     if min_delta_lat < min_delta:
         LOGGER.warning(
-            "Minimum distance between lat/lon points is less than the specified minimum distance. Defaulting to min_delta=%s.",
+            "Min. distance between lat/lon points is < specified minimum distance. Defaulting to min_delta=%s.",
             min_delta,
         )
         min_delta_lat = min_delta


### PR DESCRIPTION
- `plot_histogram`: add `density=True` in call to `np.histogram` in order to get density values and not frequencies;
- `plot_sample`: input precipitation currently does not use the same special colormap as the target/pred precipitation sample, which is fixed in this PR
-  `plot_spectrum`: add `min_delta` argument to the `PlotSpectrum` object to define a lower bound on the delta latitude value used to build the numpy array used for computation of power spectra. The current value is 0.0003 deg, which corresponds to 1km. 

Fixes #179