### PR TITLE
fix: remove saving of metadata for training ckpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Keep it human-readable, your future self will thank you!
 ### Fixed
 - Not update NaN-weight-mask for loss function when using remapper and no imputer [#178](https://github.com/ecmwf/anemoi-training/pull/178)
 - Dont crash when using the profiler if certain env vars arent set [#180](https://github.com/ecmwf/anemoi-training/pull/180)
+- Remove saving of metadata to training checkpoint [#57](https://github.com/ecmwf/anemoi-training/pull/190)
 
 ### Added
 - Introduce variable to configure: transfer_learning -> bool, True if loading checkpoint in a transfer learning setting.

--- a/src/anemoi/training/diagnostics/callbacks/checkpoint.py
+++ b/src/anemoi/training/diagnostics/callbacks/checkpoint.py
@@ -173,9 +173,6 @@ class AnemoiCheckpoint(ModelCheckpoint):
         if trainer.is_global_zero:
             from weakref import proxy
 
-            # save metadata for the training checkpoint in the same format as inference
-            save_metadata(lightning_checkpoint_filepath, metadata)
-
             # notify loggers
             for logger in trainer.loggers:
                 logger.after_save_checkpoint(proxy(self))


### PR DESCRIPTION
This PR would remove the saving of the metadata from the training checkpoint (it is still present in the inference ckpt). I am not sure if there is a reason we need it in both checkpoints?

This PR came out of the AIFSv03 training where we had quite a bit of pain restarting runs with the zip bug for checkpoints over a certain size. We had to use the work around `zip -d last.ckpt archive/anemoi-metadata/ai-models.json` many times, which this PR would get around. Very happy to be told we need this metadata in the training checkpoints! But if not this would avoid quite a bit of pain when resuming runs. 🙏  