### PR TITLE
Fix for checkpoint loading.

### DIFF
--- a/src/anemoi/training/train/train.py
+++ b/src/anemoi/training/train/train.py
@@ -162,7 +162,7 @@ class AnemoiTrainer:
 
             LOGGER.info("Restoring only model weights from %s", self.last_checkpoint)
 
-            return model.load_from_checkpoint(self.last_checkpoint, **kwargs, strict=False)
+            return GraphForecaster.load_from_checkpoint(self.last_checkpoint, **kwargs, strict=False)
 
         LOGGER.info("Model initialised from scratch.")
         return model


### PR DESCRIPTION
Changed the model loading call when resuming without transfer learning and weights_only = True.
Closes #193