### PR TITLE
Fix 'all' validation metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Keep it human-readable, your future self will thank you!
 ### Added
 
 - Support for masking out unconnected nodes in LAM [#171](https://github.com/ecmwf/anemoi-training/pull/171)
+- Improved validation metrics, allow 'all' to be scaled [#202](https://github.com/ecmwf/anemoi-training/pull/202)
 
 ## [0.3.1 - AIFS v0.3 Compatibility](https://github.com/ecmwf/anemoi-training/compare/0.3.0...0.3.1) - 2024-11-28
 

--- a/docs/modules/losses.rst
+++ b/docs/modules/losses.rst
@@ -73,10 +73,35 @@ Currently, the following scalars are available for use:
 ********************
 
 Validation metrics as defined in the config file at
-``config.training.validation_metrics`` follow the same initialise
+``config.training.validation_metrics`` follow the same initialisation
 behaviour as the loss function, but can be a list. In this case all
 losses are calculated and logged as a dictionary with the corresponding
 name
+
+Scaling Validation Losses
+=========================
+
+Validation metrics can **not** by default be scaled by scalars across
+the variable dimension, but can be by all other scalars. If you want to
+scale a validation metric by the variable weights, it must be added to
+`config.training.scale_validation_metrics`.
+
+These metrics are then kept in the normalised, preprocessed space, and
+thus the indexing of scalars aligns with the indexing of the tensors.
+
+By default, only `all` is kept in the normalised space and scaled.
+
+.. code:: yaml
+
+   # List of validation metrics to keep in normalised space, and scalars to be applied
+   # Use '*' in reference all metrics, or a list of metric names.
+   # Unlike above, variable scaling is possible due to these metrics being
+   # calculated in the same way as the training loss, within the internal model space.
+   scale_validation_metrics:
+   scalars_to_apply: ['variable']
+   metrics:
+      - 'all'
+      # - "*"
 
 ***********************
  Custom Loss Functions

--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -58,12 +58,16 @@ loss_gradient_scaling: False
 
 # Validation metrics calculation,
 # This may be a list, in which case all metrics will be calculated
-# and logged according to their name
+# and logged according to their name.
+# These metrics are calculated in the output model space, and thus
+# have undergone postprocessing.
 validation_metrics:
   # loss class to initialise
   - _target_: anemoi.training.losses.mse.WeightedMSELoss
     # Scalars to include in loss calculation
     # Cannot scale over the variable dimension due to possible remappings.
+    # Available scalars include:
+    # - 'loss_weights_mask': Giving imputed NaNs a zero weight in the loss function
     # Use the `scale_validation_metrics` section to variable scale.
     scalars: []
     # other kwargs
@@ -71,6 +75,8 @@ validation_metrics:
 
 # List of validation metrics to keep in normalised space, and scalars to be applied
 # Use '*' in reference all metrics, or a list of metric names.
+# Unlike above, variable scaling is possible due to these metrics being
+# calculated in the same way as the training loss, within the internal model space.
 scale_validation_metrics:
   scalars_to_apply: ['variable']
   metrics:

--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -63,18 +63,19 @@ validation_metrics:
   # loss class to initialise
   - _target_: anemoi.training.losses.mse.WeightedMSELoss
     # Scalars to include in loss calculation
-    # Available scalars include, 'variable'
+    # Cannot scale over the variable dimension due to possible remappings.
+    # Use the `scale_validation_metrics` section to variable scale.
     scalars: []
     # other kwargs
     ignore_nans: True
 
-# List of validation metrics to keep in normalised space, and scalars to apply
-# Cannot be used for metrics associated with variables that are remapped between the
-# real space and internal model space.
+# List of validation metrics to keep in normalised space, and scalars to be applied
+# Use '*' in reference all metrics, or a list of metric names.
 scale_validation_metrics:
   scalars_to_apply: ['variable']
   metrics:
     - 'all'
+    # - "*"
 
 
 # length of the "rollout" window (see Keisler's paper)

--- a/src/anemoi/training/config/training/default.yaml
+++ b/src/anemoi/training/config/training/default.yaml
@@ -68,6 +68,15 @@ validation_metrics:
     # other kwargs
     ignore_nans: True
 
+# List of validation metrics to keep in normalised space, and scalars to apply
+# Cannot be used for metrics associated with variables that are remapped between the
+# real space and internal model space.
+scale_validation_metrics:
+  scalars_to_apply: ['variable']
+  metrics:
+    - 'all'
+
+
 # length of the "rollout" window (see Keisler's paper)
 rollout:
   start: 1

--- a/src/anemoi/training/losses/utils.py
+++ b/src/anemoi/training/losses/utils.py
@@ -186,7 +186,7 @@ class ScaleTensor:
         scalar: torch.Tensor,
         *,
         name: str | None = None,
-    ) -> None:
+    ) -> ScaleTensor:
         """Add new scalar to be applied along `dimension`.
 
         Dimension can be a single int even for a multi-dimensional scalar,
@@ -201,6 +201,11 @@ class ScaleTensor:
             Scalar tensor to apply
         name : str | None, optional
             Name of the scalar, by default None
+
+        Returns
+        -------
+        ScaleTensor
+            ScaleTensor with the scalar removed
         """
         if not isinstance(scalar, torch.Tensor):
             scalar = torch.tensor([scalar]) if isinstance(scalar, (int, float)) else torch.tensor(scalar)
@@ -229,27 +234,31 @@ class ScaleTensor:
         self.tensors[name] = (dimension, scalar)
         self._specified_dimensions[name] = dimension
 
-    def remove_scalar(self, name: str) -> None:
+        return self
+
+    def remove_scalar(self, scalar_to_remove: str | int) -> ScaleTensor:
         """
         Remove scalar from ScaleTensor.
 
         Parameters
         ----------
-        name : str
-            Name of tensor to remove
+        scalar_to_remove : str | int
+            Name or index of tensor to remove
 
         Raises
         ------
         ValueError
             If the scalar is not in the scalars
-        """
-        if name not in self.tensors:
-            valid_keys = list(self.tensors.keys())
-            error_msg = f"{name} not in scalars. Must be one of {valid_keys}."
-            raise ValueError(error_msg)
 
-        self.tensors.pop(name)
-        self._specified_dimensions.pop(name)
+        Returns
+        -------
+        ScaleTensor
+            ScaleTensor with the scalar removed
+        """
+        for scalar_to_pop in self.subset(scalar_to_remove).tensors:
+            self.tensors.pop(scalar_to_pop)
+            self._specified_dimensions.pop(scalar_to_pop)
+        return self
 
     def freeze_state(self) -> FrozenStateRecord:  # noqa: F821
         """
@@ -260,7 +269,7 @@ class ScaleTensor:
         Returns
         -------
         FrozenStateRecord
-            Context manager to freeze the state
+            Context manager to freeze the state of this ScaleTensor
         """
         record_of_scalars: dict = self.tensors.copy()
 
@@ -352,7 +361,26 @@ class ScaleTensor:
         for name, tensor in kwargs.items():
             self.update_scalar(name, tensor, override=override)
 
-    def subset(self, scalars: str | Sequence[str]) -> ScaleTensor:
+    def subset(self, scalar_identifier: str | Sequence[str] | int | Sequence[int]) -> ScaleTensor:
+        """Get subset of the scalars, filtering by name or dimension.
+
+        Parameters
+        ----------
+        scalar_identifier : str | Sequence[str] | int | Sequence[int]
+            Name/s or dimension/s of the scalars to get
+
+        Returns
+        -------
+        ScaleTensor
+            Subset of self
+        """
+        if isinstance(scalar_identifier, (str, int)):
+            scalar_identifier = [scalar_identifier]
+        if any(isinstance(scalar, int) for scalar in scalar_identifier):
+            return self.subset_by_dim(scalar_identifier)
+        return self.subset_by_str(scalar_identifier)
+
+    def subset_by_str(self, scalars: str | Sequence[str]) -> ScaleTensor:
         """Get subset of the scalars, filtering by name.
 
         See `.subset_by_dim` for subsetting by affected dimensions.
@@ -370,23 +398,6 @@ class ScaleTensor:
         if isinstance(scalars, str):
             scalars = [scalars]
         return ScaleTensor(**{name: self.tensors[name] for name in scalars})
-
-    def without(self, scalars: str | Sequence[str]) -> ScaleTensor:
-        """Get subset of the scalars, filtering out by name.
-
-        Parameters
-        ----------
-        scalars : str | Sequence[str]
-            Name/s of the scalars to exclude
-
-        Returns
-        -------
-        ScaleTensor
-            Subset of self
-        """
-        if isinstance(scalars, str):
-            scalars = [scalars]
-        return ScaleTensor(**{name: tensor for name, tensor in self.tensors.items() if name not in scalars})
 
     def subset_by_dim(self, dimensions: int | Sequence[int]) -> ScaleTensor:
         """Get subset of the scalars, filtering by dimension.
@@ -415,6 +426,42 @@ class ScaleTensor:
                 subset_scalars[name] = (dim, scalar)
 
         return ScaleTensor(**subset_scalars)
+
+    def without(self, scalar_identifier: str | Sequence[str] | int | Sequence[int]) -> ScaleTensor:
+        """Get subset of the scalars, filtering out by name or dimension.
+
+        Parameters
+        ----------
+        scalar_identifier : str | Sequence[str] | int | Sequence[int]
+            Name/s or dimension/s of the scalars to exclude
+
+        Returns
+        -------
+        ScaleTensor
+            Subset of self
+        """
+        if isinstance(scalar_identifier, (str, int)):
+            scalar_identifier = [scalar_identifier]
+        if any(isinstance(scalar, int) for scalar in scalar_identifier):
+            return self.without_by_dim(scalar_identifier)
+        return self.without_by_str(scalar_identifier)
+
+    def without_by_str(self, scalars: str | Sequence[str]) -> ScaleTensor:
+        """Get subset of the scalars, filtering out by name.
+
+        Parameters
+        ----------
+        scalars : str | Sequence[str]
+            Name/s of the scalars to exclude
+
+        Returns
+        -------
+        ScaleTensor
+            Subset of self
+        """
+        if isinstance(scalars, str):
+            scalars = [scalars]
+        return ScaleTensor(**{name: tensor for name, tensor in self.tensors.items() if name not in scalars})
 
     def without_by_dim(self, dimensions: int | Sequence[int]) -> ScaleTensor:
         """Get subset of the scalars, filtering out by dimension.

--- a/src/anemoi/training/losses/weightedloss.py
+++ b/src/anemoi/training/losses/weightedloss.py
@@ -108,7 +108,7 @@ class BaseWeightedLoss(nn.Module, ABC):
 
         scalar = scale_tensor.get_scalar(x.ndim).to(x)
 
-        scalar = scalar.expand_as(x)        
+        scalar = scalar.expand_as(x)
         return x[subset_indices] * scalar[subset_indices]
 
     def scale_by_node_weights(self, x: torch.Tensor, squash: bool = True) -> torch.Tensor:

--- a/src/anemoi/training/losses/weightedloss.py
+++ b/src/anemoi/training/losses/weightedloss.py
@@ -72,7 +72,7 @@ class BaseWeightedLoss(nn.Module, ABC):
     def scale(
         self,
         x: torch.Tensor,
-        scalar_indices: tuple[int, ...] | None = None,
+        subset_indices: tuple[int, ...] | None = None,
         *,
         without_scalars: list[str] | list[int] | None = None,
     ) -> torch.Tensor:
@@ -82,8 +82,8 @@ class BaseWeightedLoss(nn.Module, ABC):
         ----------
         x : torch.Tensor
             Tensor to be scaled, shape (bs, ensemble, lat*lon, n_outputs)
-        scalar_indices: tuple[int,...], optional
-            Indices to subset the calculated scalar with, by default None.
+        subset_indices: tuple[int,...], optional
+            Indices to subset the calculated scalar and `x` tensor with, by default None.
         without_scalars: list[str] | list[int] | None, optional
             list of scalars to exclude from scaling. Can be list of names or dimensions to exclude.
             By default None
@@ -93,8 +93,11 @@ class BaseWeightedLoss(nn.Module, ABC):
         torch.Tensor
             Scaled error tensor
         """
+        if subset_indices is None:
+            subset_indices = [Ellipsis]
+
         if len(self.scalar) == 0:
-            return x
+            return x[subset_indices]
 
         scale_tensor = self.scalar
         if without_scalars is not None and len(without_scalars) > 0:
@@ -105,11 +108,8 @@ class BaseWeightedLoss(nn.Module, ABC):
 
         scalar = scale_tensor.get_scalar(x.ndim).to(x)
 
-        if scalar_indices is None:
-            return x * scalar
-
-        scalar = scalar.expand_as(x)
-        return x * scalar[scalar_indices]
+        scalar = scalar.expand_as(x)        
+        return x[subset_indices] * scalar[subset_indices]
 
     def scale_by_node_weights(self, x: torch.Tensor, squash: bool = True) -> torch.Tensor:
         """Scale a tensor by the node_weights.

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -607,16 +607,15 @@ class GraphForecaster(pl.LightningModule):
                             internal_model_indices = self._remap_output_to_internal_indices(indices)
 
                         metrics[f"{metric_name}/{mkey}/{rollout_step + 1}"] = metric(
-                            y[..., internal_model_indices],
-                            y_pred[..., internal_model_indices],
-                            scalar_indices=[..., internal_model_indices] if -1 in metric.scalar else None,
+                            y_pred,
+                            y,
+                            scalar_indices=[..., internal_model_indices],
                         )
-
                 else:
                     metrics[f"{metric_name}/{mkey}/{rollout_step + 1}"] = metric(
-                        y_pred_postprocessed[..., indices],
-                        y_postprocessed[..., indices],
-                        scalar_indices=[..., indices] if -1 in metric.scalar else None,
+                        y_pred_postprocessed,
+                        y_postprocessed,
+                        scalar_indices=[..., indices]
                     )
 
         return metrics

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -600,8 +600,11 @@ class GraphForecaster(pl.LightningModule):
                         for key in self.config.training.scale_validation_metrics.scalars_to_apply:
                             metric.add_scalar(*self.scalars[key], name=key)
 
-                        # Use normalised space data
-                        internal_model_indices = self._remap_output_to_internal_indices(indices)
+                        # Use internal model space indices
+                        if "mkey" == "all":
+                            internal_model_indices = self.data_indices.model.output.full.tolist()
+                        else:
+                            internal_model_indices = self._remap_output_to_internal_indices(indices)
 
                         metrics[f"{metric_name}/{mkey}/{rollout_step + 1}"] = metric(
                             y[..., internal_model_indices],

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -251,8 +251,8 @@ class GraphForecaster(pl.LightningModule):
                     loss_weights_mask = pre_processor.transform_loss_mask(loss_weights_mask)
             # update scaler with loss_weights_mask retrieved from preprocessors
             self.loss.update_scalar(scalar=loss_weights_mask.cpu(), name="loss_weights_mask")
+            self.scalars["loss_weights_mask"] = ((-2, -1), loss_weights_mask.cpu())
 
-        self.scalars["loss_weights_mask"] = ((-2, -1), loss_weights_mask.cpu())
         self.updated_loss_mask = True
 
     @staticmethod

--- a/tests/train/test_scalar.py
+++ b/tests/train/test_scalar.py
@@ -168,33 +168,72 @@ def test_scale_tensor_two_dim(
     torch.testing.assert_close(scale.scale(input_tensor), output)
 
 
-def test_scalar_subset() -> None:
-    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(0, torch.tensor([3.0])))
-    subset = scale.subset("test")
+@pytest.mark.parametrize("subset_id", ["test", 0])
+def test_scalar_subset(subset_id) -> None:  # noqa: ANN001
+    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    subset = scale.subset(subset_id)
     assert "test" in subset
     assert "wow" not in subset
     assert 0 in subset
+    assert 1 not in subset
 
 
-def test_scalar_subset_without() -> None:
+@pytest.mark.parametrize("without_id", ["test", 0])
+def test_scalar_subset_without(without_id) -> None:  # noqa: ANN001
+    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    subset = scale.without(without_id)
+    assert "test" not in subset
+    assert "wow" in subset
+    assert 1 in subset
+
+
+@pytest.mark.parametrize("without_id", ["test"])
+def test_scalar_subset_without_overlap(without_id) -> None:  # noqa: ANN001
     scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(0, torch.tensor([3.0])))
-    subset = scale.without("test")
+    subset = scale.without(without_id)
     assert "test" not in subset
     assert "wow" in subset
     assert 0 in subset
 
 
-def test_scalar_subset_by_dim() -> None:
+def test_scalar_remove_str() -> None:
     scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
-    subset = scale.subset_by_dim(0)
+    subset = scale.remove_scalar("wow")
     assert "test" in subset
     assert "wow" not in subset
     assert 0 in subset
 
 
-def test_scalar_subset_by_dim_without() -> None:
+def test_scalar_remove_int() -> None:
     scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
-    subset = scale.without_by_dim(0)
-    assert "test" not in subset
+    subset = scale.remove_scalar(1)
+    assert "test" in subset
+    assert "wow" not in subset
+    assert 0 in subset
+    assert 1 not in subset
+
+
+def test_scalar_freeze_str() -> None:
+    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    with scale.freeze_state():
+        subset = scale.remove_scalar("wow")
+        assert "test" in subset
+        assert "wow" not in subset
+        assert 0 in subset
+        assert 1 not in subset
+
     assert "wow" in subset
-    assert 0 not in subset
+    assert 1 in subset
+
+
+def test_scalar_freeze_int() -> None:
+    scale = ScaleTensor(test=(0, torch.tensor([2.0])), wow=(1, torch.tensor([3.0])))
+    with scale.freeze_state():
+        subset = scale.remove_scalar(1)
+        assert "test" in subset
+        assert "wow" not in subset
+        assert 0 in subset
+        assert 1 not in subset
+
+    assert "wow" in subset
+    assert 1 in subset


### PR DESCRIPTION
# Improve Validation Metrics

Allow `all` to normalised and scaled when calculating the validation metrics.

Adds a config option to control which validation_metrics stay in normalised space and which scalars are applied.

```yaml
# List of validation metrics to keep in normalised space, and scalars to apply
# Cannot be used for metrics associated with variables that are remapped between the
# real space and internal model space.
scale_validation_metrics:
  scalars_to_apply: ['variable']
  metrics:
    - 'all'
```

## Testing
- [x] Tested in default running [here](https://mlflow.ecmwf.int/#/experiments/93/runs/2c9173ff907c4ec2baa9afc1458af5ab/model-metrics)
- [ ] Stretched Grid @jswijnands [here](https://mlflow.ecmwf.int/#/experiments/30/runs/654966120d9c4e618b71d1d4b5d89e88/model-metrics)
- [x] Remapped data @sahahner 

<!-- readthedocs-preview anemoi-training start -->
----
📚 Documentation preview 📚: https://anemoi-training--202.org.readthedocs.build/en/202/

<!-- readthedocs-preview anemoi-training end -->