### PR TITLE
Fix/stretched grid check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Keep it human-readable, your future self will thank you!
 - Dont crash when using the profiler if certain env vars arent set [#180](https://github.com/ecmwf/anemoi-training/pull/180)
 - Remove saving of metadata to training checkpoint [#57](https://github.com/ecmwf/anemoi-training/pull/190)
 - Fixes to callback plots [#182] (power spectrum large numpy array error + precip cmap for cases where precip is prognostic).
+- Identify stretched grid models based on graph rather than configuration file [#204](https://github.com/ecmwf/anemoi-training/pull/204)
 
 ### Added
 - Introduce variable to configure: transfer_learning -> bool, True if loading checkpoint in a transfer learning setting.

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -103,7 +103,7 @@ class GraphForecaster(pl.LightningModule):
         _, self.val_metric_ranges = self.get_val_metric_ranges(config, data_indices)
 
         # Check if the model is a stretched grid
-        if "lam_resolution" in getattr(config.graph.nodes.hidden, "node_builder", []):
+        if graph_data["hidden"].node_type == 'StretchedTriNodes':
             mask_name = config.graph.nodes.hidden.node_builder.mask_attr_name
             limited_area_mask = graph_data[config.graph.data][mask_name].squeeze().bool()
         else:

--- a/src/anemoi/training/train/forecaster.py
+++ b/src/anemoi/training/train/forecaster.py
@@ -103,7 +103,7 @@ class GraphForecaster(pl.LightningModule):
         _, self.val_metric_ranges = self.get_val_metric_ranges(config, data_indices)
 
         # Check if the model is a stretched grid
-        if graph_data["hidden"].node_type == 'StretchedTriNodes':
+        if graph_data["hidden"].node_type == "StretchedTriNodes":
             mask_name = config.graph.nodes.hidden.node_builder.mask_attr_name
             limited_area_mask = graph_data[config.graph.data][mask_name].squeeze().bool()
         else:


### PR DESCRIPTION
In the forecaster, there is a need to identify if we are dealing with a stretched grid model. The improvement in this PR also works if an existing graph is loaded from disk, in combination with a minimal config file specification of the graph.

This code update has been checked for stretched grid models.

Review suggestion (RMI): check if this change also works for LAM models when loading an existing graph from disk using a minimal configuration script.